### PR TITLE
[ADD] Support for taking sub-matrices of linear operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ such a routine is
 [`scipy.sparse.linalg.eigsh`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html)
 that lets you compute a subset of eigenpairs.
 
+The library also provides linear operator transformations, like taking the
+inverse (inverse matrix-vector product via conjugate gradients) or slicing out
+sub-matrices.
+
 - **Documentation:** https://curvlinops.readthedocs.io/en/latest/
 
 - **Bug reports & feature requests:**
@@ -49,8 +53,6 @@ Other features that could be supported in the future include:
   - the centered gradient covariance
   - terms of the [hierarchical GGN
     decomposition](https://arxiv.org/abs/2008.11865)
-
-- Block-diagonal approximations (via `param_groups`)
 
 ###### Logo mage credits
 - SciPy logo: Unknown, [CC BY-SA

--- a/curvlinops/__init__.py
+++ b/curvlinops/__init__.py
@@ -11,6 +11,7 @@ from curvlinops.papyan2020traces.spectrum import (
     lanczos_approximate_log_spectrum,
     lanczos_approximate_spectrum,
 )
+from curvlinops.submatrix import SubmatrixLinearOperator
 
 __all__ = [
     "HessianLinearOperator",
@@ -18,6 +19,7 @@ __all__ = [
     "EFLinearOperator",
     "FisherMCLinearOperator",
     "CGInverseLinearOperator",
+    "SubmatrixLinearOperator",
     "lanczos_approximate_spectrum",
     "lanczos_approximate_log_spectrum",
     "LanczosApproximateSpectrumCached",

--- a/curvlinops/submatrix.py
+++ b/curvlinops/submatrix.py
@@ -10,7 +10,9 @@ class SubmatrixLinearOperator(LinearOperator):
     """Class for sub-matrices of linear operators."""
 
     def __init__(self, A: LinearOperator, row_idxs: List[int], col_idxs: List[int]):
-        """Store the linear operator whose inverse should be represented.
+        """Store the linear operator and indices of its sub-matrix.
+
+        Represents the sub-matrix ``A[row_idxs, :][col_idxs, :]``.
 
         Args:
             A: A linear operator.

--- a/curvlinops/submatrix.py
+++ b/curvlinops/submatrix.py
@@ -51,13 +51,13 @@ class SubmatrixLinearOperator(LinearOperator):
         self._col_idxs = col_idxs
 
     def _matvec(self, x: ndarray) -> ndarray:
-        """Multiply x by the submatrix of A.
+        """Multiply x by the sub-matrix of A.
 
         Args:
              x: Vector for multiplication. Has shape ``[len(col_idxs)]``.
 
         Returns:
-             Result of the sub-matrix-vector multiplication,
+             Result of the (sub-matrix)-vector-multiplication,
              ``A[row_idxs, :][:, col_idxs] @ x``. Has shape ``[len(row_idxs)]``.
         """
         v = zeros((self._A.shape[1],), dtype=self._A.dtype)
@@ -67,14 +67,14 @@ class SubmatrixLinearOperator(LinearOperator):
         return Av[self._row_idxs]
 
     def _matmat(self, X: ndarray) -> ndarray:
-        """Multiply each column of X by the submatrix of A.
+        """Multiply each column of X by the sub-matrix of A.
 
         Args:
             X: Matrix for multiplication. Has shape ``[len(col_idxs), N]`` with
                 abitrary ``N``.
 
         Returns:
-            Matrix-multiplication result ``A[row_idxs, :][:, col_idxs] @ x``.
-            Has shape ``[len(row_idxs), N]``.
+            Result of the (sub-matrix)-matrix-multiplication,
+            ``A[row_idxs, :][:, col_idxs] @ x``. Has shape ``[len(row_idxs), N]``.
         """
         return column_stack([self @ col for col in X.T])

--- a/curvlinops/submatrix.py
+++ b/curvlinops/submatrix.py
@@ -58,7 +58,7 @@ class SubmatrixLinearOperator(LinearOperator):
 
         Returns:
              Result of the sub-matrix-vector multiplication,
-            ``A[row_idxs, :][:, col_idxs] @ x``. Has shape ``[len(row_idxs)]``.
+             ``A[row_idxs, :][:, col_idxs] @ x``. Has shape ``[len(row_idxs)]``.
         """
         v = zeros((self._A.shape[1],), dtype=self._A.dtype)
         v[self._col_idxs] = x

--- a/curvlinops/submatrix.py
+++ b/curvlinops/submatrix.py
@@ -1,0 +1,78 @@
+"""Implements slices of linear operators."""
+
+from typing import List
+
+from numpy import column_stack, ndarray, zeros
+from scipy.sparse.linalg import LinearOperator
+
+
+class SubmatrixLinearOperator(LinearOperator):
+    """Class for sub-matrices of linear operators."""
+
+    def __init__(self, A: LinearOperator, row_idxs: List[int], col_idxs: List[int]):
+        """Store the linear operator whose inverse should be represented.
+
+        Args:
+            A: A linear operator.
+            row_idxs: The sub-matrix's row indices.
+            col_idxs: The sub-matrix's column indices.
+        """
+        self._A = A
+        self.set_submatrix(row_idxs, col_idxs)
+
+    def set_submatrix(self, row_idxs: List[int], col_idxs: List[int]):
+        """Define the sub-matrix.
+
+        Internally sets the linear operator's shape.
+
+        Args:
+            row_idxs: The sub-matrix's row indices.
+            col_idxs: The sub-matrix's column indices.
+
+        Raises:
+            ValueError: If the index lists contain duplicate values, non-integers,
+                or out-of-bounds indices.
+        """
+        shape = []
+
+        for ax_idx, idxs in enumerate([row_idxs, col_idxs]):
+            if any(not isinstance(i, int) for i in idxs):
+                raise ValueError("Index lists must contain integers.")
+            if len(idxs) != len(set(idxs)):
+                raise ValueError("Index lists cannot contain duplicates.")
+            if any(i < 0 or i >= self._A.shape[ax_idx] for i in idxs):
+                raise ValueError("Index lists contain out-of-bounds indices.")
+            shape.append(len(idxs))
+
+        super().__init__(self._A.dtype, shape)
+        self._row_idxs = row_idxs
+        self._col_idxs = col_idxs
+
+    def _matvec(self, x: ndarray) -> ndarray:
+        """Multiply x by the submatrix of A.
+
+        Args:
+             x: Vector for multiplication. Has shape ``[len(col_idxs)]``.
+
+        Returns:
+             Result of the sub-matrix-vector multiplication,
+            ``A[row_idxs, :][:, col_idxs] @ x``. Has shape ``[len(row_idxs)]``.
+        """
+        v = zeros((self._A.shape[1],), dtype=self._A.dtype)
+        v[self._col_idxs] = x
+        Av = self._A @ v
+
+        return Av[self._row_idxs]
+
+    def _matmat(self, X: ndarray) -> ndarray:
+        """Multiply each column of X by the submatrix of A.
+
+        Args:
+            X: Matrix for multiplication. Has shape ``[len(col_idxs), N]`` with
+                abitrary ``N``.
+
+        Returns:
+            Matrix-multiplication result ``A[row_idxs, :][:, col_idxs] @ x``.
+            Has shape ``[len(row_idxs), N]``.
+        """
+        return column_stack([self @ col for col in X.T])

--- a/docs/rtd/conf.py
+++ b/docs/rtd/conf.py
@@ -22,7 +22,7 @@ copyright = "2022, F. Dangel, L. Tatzel"
 author = "F. Dangel, L. Tatzel"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.1"
+release = "1.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/rtd/linops.rst
+++ b/docs/rtd/linops.rst
@@ -32,6 +32,12 @@ Inverses
 .. autoclass:: curvlinops.CGInverseLinearOperator
    :members: __init__, set_cg_hyperparameters
 
+Sub-matrices
+------------
+
+.. autoclass:: curvlinops.SubmatrixLinearOperator
+   :members: __init__, set_submatrix
+
 Spectral density approximation
 ==============================
 

--- a/test/test_submatrix.py
+++ b/test/test_submatrix.py
@@ -1,0 +1,60 @@
+"""Contains tests for ``curvlinops/submatrix`` with random matrices."""
+
+from typing import List, Tuple
+
+from numpy import ndarray, random
+from pytest import fixture
+from scipy.sparse.linalg import aslinearoperator
+
+from curvlinops.examples.utils import report_nonclose
+from curvlinops.submatrix import SubmatrixLinearOperator
+
+SUBMATRIX_CASES = [
+    # same indices
+    {
+        "A_fn": lambda: random.rand(300, 300),
+        "row_idxs_fn": lambda: [0, 13, 42, 299],
+        "col_idxs_fn": lambda: [0, 13, 42, 299],
+        "seed": 0,
+    },
+    # different indices
+    {
+        "A_fn": lambda: random.rand(200, 250),
+        "row_idxs_fn": lambda: [5, 67, 128],
+        "col_idxs_fn": lambda: [83, 21],
+        "seed": 0,
+    },
+]
+
+
+@fixture(params=SUBMATRIX_CASES)
+def submatrix_case(request) -> Tuple[ndarray, List[int], List[int]]:
+    case = request.param
+    random.seed(case["seed"])
+    return case["A_fn"](), case["row_idxs_fn"](), case["col_idxs_fn"]()
+
+
+def test_SubmatrixLinearOperator__matvec(submatrix_case):
+    A, row_idxs, col_idxs = submatrix_case
+
+    A_sub = A[row_idxs, :][:, col_idxs]
+    A_sub_linop = SubmatrixLinearOperator(aslinearoperator(A), row_idxs, col_idxs)
+
+    x = random.rand(len(col_idxs))
+    A_sub_linop_x = A_sub_linop @ x
+
+    assert A_sub_linop_x.shape == (len(row_idxs),)
+    report_nonclose(A_sub @ x, A_sub_linop_x)
+
+
+def test_SubmatrixLinearOperator__matmat(submatrix_case, num_vecs: int = 3):
+    A, row_idxs, col_idxs = submatrix_case
+
+    A_sub = A[row_idxs, :][:, col_idxs]
+    A_sub_linop = SubmatrixLinearOperator(aslinearoperator(A), row_idxs, col_idxs)
+
+    X = random.rand(len(col_idxs), num_vecs)
+    A_sub_linop_X = A_sub_linop @ X
+
+    assert A_sub_linop_X.shape == (len(row_idxs), num_vecs)
+    report_nonclose(A_sub @ X, A_sub_linop_X)

--- a/test/test_submatrix.py
+++ b/test/test_submatrix.py
@@ -2,8 +2,8 @@
 
 from typing import List, Tuple
 
-from numpy import ndarray, random
-from pytest import fixture
+from numpy import eye, ndarray, random
+from pytest import fixture, raises
 from scipy.sparse.linalg import aslinearoperator
 
 from curvlinops.examples.utils import report_nonclose
@@ -58,3 +58,20 @@ def test_SubmatrixLinearOperator__matmat(submatrix_case, num_vecs: int = 3):
 
     assert A_sub_linop_X.shape == (len(row_idxs), num_vecs)
     report_nonclose(A_sub @ X, A_sub_linop_X)
+
+
+def test_SubmatrixLinearOperator_set_submatrix():
+    A = aslinearoperator(eye(10))
+
+    invalid_idxs = [
+        [[0.0], [0]],  # wrong type in row_idxs
+        [[0], [0.0]],  # wrong type in col_idxs
+        [[2, 1, 2], [3]],  # duplicate entries in row_idxs
+        [[3], [2, 1, 2]],  # duplicate entries in col_idxs
+        [[10, 5], [2]],  # out-of-bounds in row_idxs
+        [[6, 5], [-1]],  # out-of-bounds in col_idxs
+    ]
+
+    for row_idxs, col_idxs in invalid_idxs:
+        with raises(ValueError):
+            SubmatrixLinearOperator(A, row_idxs, col_idxs)

--- a/test/test_submatrix_on_curvatures.py
+++ b/test/test_submatrix_on_curvatures.py
@@ -1,0 +1,102 @@
+"""Contains tests for ``curvlinops/submatrix`` on curvature linear operators."""
+
+from typing import List
+
+from numpy import random
+from pytest import mark
+
+from curvlinops import EFLinearOperator, GGNLinearOperator, HessianLinearOperator
+from curvlinops.examples.functorch import (
+    functorch_empirical_fisher,
+    functorch_ggn,
+    functorch_hessian,
+)
+from curvlinops.examples.utils import report_nonclose
+from curvlinops.submatrix import SubmatrixLinearOperator
+
+CURVATURE_CASES = [HessianLinearOperator, GGNLinearOperator, EFLinearOperator]
+CURVATURE_IN_FUNCTORCH = {
+    HessianLinearOperator: functorch_hessian,
+    GGNLinearOperator: functorch_ggn,
+    EFLinearOperator: functorch_empirical_fisher,
+}
+
+
+def even_idxs(dim: int) -> List[int]:
+    return list(range(0, dim, 2))
+
+
+def odd_idxs(dim: int) -> List[int]:
+    return list(range(1, dim, 2))
+
+
+def every_third_idxs(dim: int):
+    return list(range(0, dim, 3))
+
+
+SUBMATRIX_CASES = [
+    # same indices for rows and columns (square matrix)
+    {
+        "row_idx_fn": even_idxs,
+        "col_idx_fn": even_idxs,
+    },
+    # different indices for rows and columns (square matrix if dim is even)
+    {
+        "row_idx_fn": even_idxs,
+        "col_idx_fn": odd_idxs,
+    },
+    # different indices for rows and columns (rectangular matrix if dim>5)
+    {
+        "row_idx_fn": odd_idxs,
+        "col_idx_fn": every_third_idxs,
+    },
+]
+SUBMATRIX_IDS = [
+    f"({case['row_idx_fn'].__name__},{case['col_idx_fn'].__name__})"
+    for case in SUBMATRIX_CASES
+]
+
+
+def setup_submatrix_linear_operator(case, operator_case, submatrix_case):
+    _, _, params, _ = case
+    dim = sum(p.numel() for p in params)
+    row_idxs = submatrix_case["row_idx_fn"](dim)
+    col_idxs = submatrix_case["col_idx_fn"](dim)
+
+    A = operator_case(*case)
+    A_sub = SubmatrixLinearOperator(A, row_idxs, col_idxs)
+
+    A_functorch = CURVATURE_IN_FUNCTORCH[operator_case](*case)
+    A_sub_functorch = A_functorch[row_idxs, :][:, col_idxs].detach().cpu().numpy()
+
+    return A_sub, A_sub_functorch, row_idxs, col_idxs
+
+
+@mark.parametrize("operator_case", CURVATURE_CASES)
+@mark.parametrize("submatrix_case", SUBMATRIX_CASES)
+def test_SubmatrixLinearOperator_on_curvatures_matvec(
+    case, operator_case, submatrix_case
+):
+    A_sub, A_sub_functorch, row_idxs, col_idxs = setup_submatrix_linear_operator(
+        case, operator_case, submatrix_case
+    )
+    x = random.rand(len(col_idxs)).astype(A_sub.dtype)
+    A_sub_x = A_sub @ x
+
+    assert A_sub_x.shape == (len(row_idxs),)
+    report_nonclose(A_sub_x, A_sub_functorch @ x)
+
+
+@mark.parametrize("operator_case", CURVATURE_CASES)
+@mark.parametrize("submatrix_case", SUBMATRIX_CASES)
+def test_SubmatrixLinearOperator_on_curvatures_matmat(
+    case, operator_case, submatrix_case, num_vecs: int = 3
+):
+    A_sub, A_sub_functorch, row_idxs, col_idxs = setup_submatrix_linear_operator(
+        case, operator_case, submatrix_case
+    )
+    X = random.rand(len(col_idxs), num_vecs).astype(A_sub.dtype)
+    A_sub_X = A_sub @ X
+
+    assert A_sub_X.shape == (len(row_idxs), num_vecs)
+    report_nonclose(A_sub_X, A_sub_functorch @ X, atol=5e-7)


### PR DESCRIPTION
Given a linear operator `A`, the `SubmatrixLinearOperator` class allows
constructing the linear operator for `A[row_idxs, :][:, col_idxs]`.
The sub-matrix can be changed after initialization using the
`set_submatrix` method.