### PR TITLE
[REF] Use built in functorch, use BackPACK 1.6

### DIFF
--- a/curvlinops/examples/functorch.py
+++ b/curvlinops/examples/functorch.py
@@ -173,7 +173,7 @@ def functorch_gradient(
     params_argnum = 2
     grad_fn = grad(loss, argnums=params_argnum)
 
-    return grad_fn(X, y, params_dict)
+    return tuple(grad_fn(X, y, params_dict).values())
 
 
 def functorch_empirical_fisher(

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    backpack-for-pytorch>=1.5.0,<2.0.0
+    backpack-for-pytorch>=1.6.0,<2.0.0
     torch>=2.0
     scipy>=1.7.1,<2.0.0
     tqdm>=4.61.0,<5.0.0
@@ -73,7 +73,6 @@ lint =
 # Dependencies needed to build/view the documentation (semicolon/line-separated)
 docs =
     matplotlib
-    functorch
     sphinx-gallery
     sphinx-rtd-theme
 


### PR DESCRIPTION
Updates the dependencies such that BackPACK with PyTorch>=2 is used.
Refactors the `functorch` utilities to use the new API from `torch.func`.
Removes dependency from separate `functorch` package.