### PR TITLE
[ADD] Minimal prototype for KFAC

### DIFF
--- a/curvlinops/__init__.py
+++ b/curvlinops/__init__.py
@@ -7,6 +7,7 @@ from curvlinops.gradient_moments import EFLinearOperator
 from curvlinops.hessian import HessianLinearOperator
 from curvlinops.inverse import CGInverseLinearOperator, NeumannInverseLinearOperator
 from curvlinops.jacobian import JacobianLinearOperator, TransposedJacobianLinearOperator
+from curvlinops.kfac import KFACLinearOperator
 from curvlinops.papyan2020traces.spectrum import (
     LanczosApproximateLogSpectrumCached,
     LanczosApproximateSpectrumCached,
@@ -22,6 +23,7 @@ __all__ = [
     "GGNLinearOperator",
     "EFLinearOperator",
     "FisherMCLinearOperator",
+    "KFACLinearOperator",
     "JacobianLinearOperator",
     "TransposedJacobianLinearOperator",
     "CGInverseLinearOperator",

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -1,6 +1,7 @@
 """Contains functionality to analyze Hessian & GGN via matrix-free multiplication."""
 
 from typing import Callable, Iterable, List, Optional, Tuple, Union
+from warnings import warn
 
 from backpack.utils.convert_parameters import vector_to_parameter_list
 from numpy import (
@@ -254,6 +255,13 @@ class _LinearOperator(LinearOperator):
         Returns:
             Vector in list format.
         """
+        if x.dtype != self.dtype:
+            warn(
+                f"Input vector is {x.dtype}, while linear operator is {self.dtype}. "
+                + f"Converting to {self.dtype}."
+            )
+            x = x.astype(self.dtype)
+
         x_torch = from_numpy(x).to(self._device)
         return vector_to_parameter_list(x_torch, self._params)
 

--- a/curvlinops/examples/utils.py
+++ b/curvlinops/examples/utils.py
@@ -31,5 +31,7 @@ def report_nonclose(
     else:
         for a1, a2 in zip(array1.flatten(), array2.flatten()):
             if not isclose(a1, a2, atol=atol, rtol=rtol, equal_nan=equal_nan):
-                print(f"{a1} ≠ {a2}")
+                print(f"{a1} ≠ {a2} (ratio {a1 / a2:.5f})")
+        print(f"Max: {array1.max():.5f}, {array2.max():.5f}")
+        print(f"Min: {array1.min():.5f}, {array2.min():.5f}")
         raise ValueError("Compared arrays don't match.")

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -1,0 +1,211 @@
+"""Linear operator for the Fisher/GGN's Kronecker-factored approximation.
+
+Kronecker-factored approximate curvature was originally introduced for MLPs in
+
+- Martens, J., & Grosse, R. (2015). Optimizing neural networks with Kronecker-factored
+  approximate curvature. International Conference on Machine Learning (ICML).
+
+and extended to CNNs in
+
+- Grosse, R., & Martens, J. (2016). A kronecker-factored approximate Fisher matrix for
+  convolution layers. International Conference on Machine Learning (ICML).
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+from typing import Dict, Iterable, List, Tuple, Union
+
+from numpy import ndarray
+from torch import Generator, Tensor, einsum, randn
+from torch.nn import CrossEntropyLoss, Linear, Module, MSELoss, Parameter
+from torch.utils.hooks import RemovableHandle
+
+from curvlinops._base import _LinearOperator
+
+
+class KFACLinearOperator(_LinearOperator):
+    """Linear operator to multiply with Fisher/GGN's KFAC approximation."""
+
+    _SUPPORTED_LOSSES = (MSELoss, CrossEntropyLoss)
+
+    def __init__(
+        self,
+        model_func: Module,
+        loss_func: Union[MSELoss, CrossEntropyLoss],
+        params: List[Parameter],
+        data: Iterable[Tuple[Tensor, Tensor]],
+        progressbar: bool = False,
+        check_deterministic: bool = True,
+        shape: Union[Tuple[int, int], None] = None,
+        seed: int = 2147483647,
+        mc_samples: int = 1,
+    ):
+        if not isinstance(loss_func, self._SUPPORTED_LOSSES):
+            raise ValueError(
+                f"Invalid loss: {loss_func}. Supported: {self._SUPPORTED_LOSSES}."
+            )
+
+        # TODO Check for only linear layers
+        idx = 0
+        for mod in model_func.modules():
+            if len(list(mod.modules())) == 1 and list(mod.parameters()):
+                assert isinstance(mod, Linear)
+                assert mod.bias is not None
+                assert params[idx].data_ptr() == mod.weight.data_ptr()
+                assert params[idx + 1].data_ptr() == mod.bias.data_ptr()
+                idx += 2
+
+        self._seed = seed
+        self._generator: Union[None, Generator] = None
+        self._mc_samples = mc_samples
+        self._input_covariances: Dict[Tuple[int, ...], Tensor] = {}
+        self._gradient_covariances: Dict[Tuple[int, ...], Tensor] = {}
+
+        super().__init__(
+            model_func,
+            loss_func,
+            params,
+            data,
+            progressbar=progressbar,
+            check_deterministic=check_deterministic,
+            shape=shape,
+        )
+
+    def _matvec(self, x: ndarray) -> ndarray:
+        """Loop over all batches in the data and apply the matrix to vector x.
+
+        Create and seed the random number generator.
+
+        Args:
+            x: Vector for multiplication.
+
+        Returns:
+            Matrix-multiplication result ``mat @ x``.
+        """
+        if not self._input_covariances and not self._gradient_covariances:
+            self._compute_kfac()
+
+        x_torch = super()._preprocess(x)
+        assert len(x_torch) % 2 == 0
+
+        for idx in range(len(x_torch) // 2):
+            idx_weight, idx_bias = 2 * idx, 2 * idx + 1
+            weight, bias = self._params[idx_weight], self._params[idx_bias]
+            x_weight, x_bias = x_torch[idx_weight], x_torch[idx_bias]
+
+            aaT = self._input_covariances[(weight.data_ptr(), bias.data_ptr())]
+            ggT = self._gradient_covariances[(weight.data_ptr(), bias.data_ptr())]
+
+            x_torch[idx_weight] = ggT @ x_weight @ aaT
+            x_torch[idx_bias] = ggT @ x_bias
+
+        return super()._postprocess(x_torch)
+
+    def _adjoint(self) -> KFACLinearOperator:
+        """Return the linear operator representing the adjoint.
+
+        The KFAC approximation is real symmetric, and hence self-adjoint.
+
+        Returns:
+            Self.
+        """
+        return self
+
+    def _compute_kfac(self):
+        # install forward and backward hooks on layers
+        hook_handles: List[RemovableHandle] = []
+
+        modules = []
+        for mod in self._model_func.modules():
+            if len(list(mod.modules())) == 1 and list(mod.parameters()):
+                assert isinstance(mod, Linear)
+                modules.append(mod)
+        hook_handles.extend(
+            mod.register_forward_pre_hook(self._hook_accumulate_input_covariance)
+            for mod in modules
+        )
+        hook_handles.extend(
+            mod.register_full_backward_hook(self._hook_accumulate_gradient_covariance)
+            for mod in modules
+        )
+
+        # loop over data set
+        if self._generator is None:
+            self._generator = Generator(device=self._device)
+        self._generator.manual_seed(self._seed)
+
+        for X, _ in self._loop_over_data(desc="Computing KFAC matrices"):
+            output = self._model_func(X)
+
+            for mc in range(self._mc_samples):
+                y_sampled = self.draw_label(output)
+                loss = self._loss_func(output, y_sampled)
+                loss.backward(retain_graph=mc != self._mc_samples - 1)
+
+        # remove hooks
+        for handle in hook_handles:
+            handle.remove()
+
+    def draw_label(self, output: Tensor) -> Tensor:
+        if isinstance(self._loss_func, MSELoss):
+            std = {
+                "sum": sqrt(1.0 / 2.0),
+                "mean": sqrt(output.shape[1:].numel() / 2.0),
+            }[self._loss_func.reduction]
+            perturbation = std * randn(
+                output.shape,
+                device=output.device,
+                dtype=output.dtype,
+                generator=self._generator,
+            )
+            return output.clone().detach() + perturbation
+        else:
+            raise NotImplementedError
+
+    def _hook_accumulate_gradient_covariance(
+        self, module: Module, grad_input: Tuple[Tensor], grad_output: Tuple[Tensor]
+    ):
+        assert len(grad_output) == 1
+
+        if isinstance(module, Linear):
+            grad_out = grad_output[0].data.detach()
+            assert grad_out.ndim == 2
+            idx = tuple(p.data_ptr() for p in module.parameters())
+
+            batch_size = grad_output[0].shape[0]
+            correction = {
+                "sum": 1.0 / self._mc_samples,
+                "mean": batch_size**2 / (self._N_data * self._mc_samples),
+            }[self._loss_func.reduction]
+
+            covariance = einsum("bi,bj->ij", grad_out, grad_out).mul_(correction)
+            if idx not in self._gradient_covariances:
+                self._gradient_covariances[idx] = covariance
+            else:
+                self._gradient_covariances[idx].add_(covariance)
+        else:
+            raise NotImplementedError
+
+    def _hook_accumulate_input_covariance(self, module: Module, inputs: Tuple[Tensor]):
+        assert len(inputs) == 1
+
+        if isinstance(module, Linear):
+            module_input = inputs[0].data.detach()
+            assert module_input.ndim == 2
+
+            idx = tuple(p.data_ptr() for p in module.parameters())
+            correction = {
+                "sum": 1.0 / self._N_data,
+                "mean": 1.0 / self._N_data,
+            }[self._loss_func.reduction]
+
+            covariance = einsum("bi,bj->ij", module_input, module_input).mul_(
+                correction
+            )
+            if idx not in self._input_covariances:
+                self._input_covariances[idx] = covariance
+            else:
+                self._input_covariances[idx].add_(covariance)
+        else:
+            raise NotImplementedError

--- a/docs/rtd/linops.rst
+++ b/docs/rtd/linops.rst
@@ -20,6 +20,9 @@ Fisher (approximate)
 .. autoclass:: curvlinops.FisherMCLinearOperator
    :members: __init__
 
+.. autoclass:: curvlinops.KFACLinearOperator
+   :members: __init__
+
 Uncentered gradient covariance (empirical Fisher)
 -------------------------------------------------
 

--- a/test/cases.py
+++ b/test/cases.py
@@ -17,8 +17,6 @@ from torch.utils.data import DataLoader, TensorDataset
 DEVICES = get_available_devices()
 DEVICES_IDS = [f"dev={d}" for d in DEVICES]
 
-LINOPS = []
-
 # Add test cases here
 CASES_NO_DEVICE = [
     ###############################################################################

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,13 @@
 """Contains pytest fixtures that are visible by other files."""
 
 from test.cases import ADJOINT_CASES, CASES, NON_DETERMINISTIC_CASES
+from test.kfac_cases import KFAC_EXPAND_EXACT_CASES
 from typing import Callable, Dict, Iterable, List, Tuple
 
 from numpy import random
 from pytest import fixture
-from torch import Tensor, manual_seed
+from torch import Module, Tensor, manual_seed
+from torch.nn import MSELoss
 
 
 def initialize_case(
@@ -56,3 +58,17 @@ def non_deterministic_case(
 @fixture(params=ADJOINT_CASES)
 def adjoint(request) -> bool:
     return request.param
+
+
+@fixture(params=KFAC_EXPAND_EXACT_CASES)
+def kfac_expand_exact_case(
+    request,
+) -> Tuple[Module, MSELoss, List[Tensor], Iterable[Tuple[Tensor, Tensor]],]:
+    """Prepare a test case for which KFAC-expand equals the GGN.
+
+    Yields:
+        A neural network, the mean-squared error function, a list of parameters, and
+        a data set.
+    """
+    kfac_case = request.param
+    yield initialize_case(kfac_case)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,8 +6,8 @@ from typing import Callable, Dict, Iterable, List, Tuple
 
 from numpy import random
 from pytest import fixture
-from torch import Module, Tensor, manual_seed
-from torch.nn import MSELoss
+from torch import Tensor, manual_seed
+from torch.nn import Module, MSELoss
 
 
 def initialize_case(

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -1,0 +1,44 @@
+"""Contains test cases for the KFAC linear operator."""
+
+from functools import partial
+from test.utils import get_available_devices, regression_targets
+
+from torch import rand
+from torch.nn import Linear, MSELoss, Sequential
+
+# Add test cases here, devices and loss function with different reductions will be
+# added automatically below
+KFAC_EXPAND_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [
+    ###############################################################################
+    #                                  REGRESSION                                 #
+    ###############################################################################
+    # deep linear network with scalar output
+    {
+        "model_func": lambda: Sequential(Linear(6, 3), Linear(3, 1)),
+        "data": lambda: [
+            (rand(2, 6), regression_targets((2, 1))),
+            (rand(5, 6), regression_targets((5, 1))),
+        ],
+        "seed": 0,
+    },
+    # deep linear network with vector output
+    {
+        "model_func": lambda: Sequential(Linear(5, 4), Linear(4, 3)),
+        "data": lambda: [
+            (rand(1, 5), regression_targets((1, 3))),
+            (rand(7, 5), regression_targets((7, 3))),
+        ],
+        "seed": 0,
+    },
+]
+
+KFAC_EXPAND_EXACT_CASES = []
+for case in KFAC_EXPAND_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC:
+    for device in get_available_devices():
+        for reduction in ["mean", "sum"]:
+            case_with_device_and_loss_func = {
+                **case,
+                "device": device,
+                "loss_func": partial(MSELoss, reduction=reduction),
+            }
+            KFAC_EXPAND_EXACT_CASES.append(case_with_device_and_loss_func)

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -1,0 +1,32 @@
+"""Contains tests for ``curvlinops.kfac``."""
+
+from typing import Iterable, List, Tuple
+
+from numpy import eye
+from scipy.linalg import block_diag
+from torch import Tensor
+from torch.nn import Module, MSELoss, Parameter
+
+from curvlinops.examples.utils import report_nonclose
+from curvlinops.ggn import GGNLinearOperator
+from curvlinops.kfac import KFACLinearOperator
+
+
+def test_kfac(
+    kfac_case: Tuple[Module, MSELoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]]
+):
+    model, loss_func, params, data = kfac_case
+
+    ggn_blocks = []  # list of per-parameter GGNs
+    for param in params:
+        ggn = GGNLinearOperator(model, loss_func, [param], data)
+        ggn_blocks.append(ggn @ eye(ggn.shape[1]))
+    ggn = block_diag(*ggn_blocks)
+
+    kfac = KFACLinearOperator(model, loss_func, params, data, mc_samples=2_000)
+    kfac_mat = kfac @ eye(kfac.shape[1])
+
+    atol = {"sum": 5e-1, "mean": 5e-3}[loss_func.reduction]
+    rtol = {"sum": 2e-2, "mean": 2e-2}[loss_func.reduction]
+
+    report_nonclose(ggn, kfac_mat, rtol=rtol, atol=atol)


### PR DESCRIPTION
Progress on #42. 

This adds a first prototype for a linear operator of KFAC. It has very limited support (e.g. only `Linear` layers, no weight sharing), but I think this is a good milestone to start off with (and to keep the `git diff`s manageable. The tests compare the per-layer GGN with KFAC for deep linear models with `MSELoss` for a large number of MC samples from the predictive distribution.