### PR TITLE
Add support for KFAC-expand and KFAC-reduce for `Linear` modules

### DIFF
--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -18,7 +18,6 @@ and generalized to all linear layers with weight sharing in
 
 from __future__ import annotations
 
-import warnings
 from functools import partial
 from math import sqrt
 from typing import Dict, Iterable, List, Set, Tuple, Union

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -171,6 +171,8 @@ class KFACLinearOperator(_LinearOperator):
             ValueError: If the loss average is not supported.
             ValueError: If the loss average is ``None`` and the loss function's
                 reduction is not ``'sum'``.
+            ValueError: If the loss average is not ``None`` and the loss function's
+                reduction is ``'sum'``.
             ValueError: If ``fisher_type != 'mc'`` and ``mc_samples != 1``.
             NotImplementedError: If a parameter is in an unsupported layer.
         """
@@ -189,13 +191,10 @@ class KFACLinearOperator(_LinearOperator):
                 f"Must be 'batch' or 'batch+sequence' if loss_func.reduction != 'sum'."
             )
         if loss_func.reduction == "sum" and loss_average is not None:
-            # reduction used in loss function will overwrite loss_average
-            warnings.warn(
+            raise ValueError(
                 f"Loss function uses reduction='sum', but loss_average={loss_average}."
-                " loss_average is set to None.",
-                stacklevel=2,
+                " Set loss_average to None if you want to use reduction='sum'."
             )
-            loss_average = None
         if fisher_type != "mc" and mc_samples != 1:
             raise ValueError(
                 f"Invalid mc_samples: {mc_samples}. "

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -1,14 +1,19 @@
 """Linear operator for the Fisher/GGN's Kronecker-factored approximation.
 
-Kronecker-factored approximate curvature was originally introduced for MLPs in
+Kronecker-Factored Approximate Curvature (KFAC) was originally introduced for MLPs in
 
 - Martens, J., & Grosse, R. (2015). Optimizing neural networks with Kronecker-factored
-  approximate curvature. International Conference on Machine Learning (ICML).
+  approximate curvature. International Conference on Machine Learning (ICML),
 
-and extended to CNNs in
+extended to CNNs in
 
 - Grosse, R., & Martens, J. (2016). A kronecker-factored approximate Fisher matrix for
-  convolution layers. International Conference on Machine Learning (ICML).
+  convolution layers. International Conference on Machine Learning (ICML),
+
+and generalized to all linear layers with weight sharing in
+
+- Eschenhagen, R., Immer, A., Turner, R. E., Schneider, F., Hennig, P. (2023).
+  Kronecker-Factored Approximate Curvature for Modern Neural Network Architectures (NeurIPS).
 """
 
 from __future__ import annotations

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -13,11 +13,12 @@ and extended to CNNs in
 
 from __future__ import annotations
 
+import warnings
 from functools import partial
 from math import sqrt
 from typing import Dict, Iterable, List, Set, Tuple, Union
 
-from einops import rearrange
+from einops import rearrange, reduce
 from numpy import ndarray
 from torch import Generator, Tensor, cat, einsum, randn, stack
 from torch.nn import CrossEntropyLoss, Linear, Module, MSELoss, Parameter
@@ -76,6 +77,7 @@ class KFACLinearOperator(_LinearOperator):
         "batch",
         "batch+sequence",
     )
+    _SUPPORTED_KFAC_APPROX: Tuple[str, ...] = ("expand", "reduce")
 
     def __init__(
         self,
@@ -89,6 +91,7 @@ class KFACLinearOperator(_LinearOperator):
         seed: int = 2147483647,
         fisher_type: str = "mc",
         mc_samples: int = 1,
+        kfac_approx: str = "expand",
         loss_average: Union[None, str] = "batch",
         separate_weight_and_bias: bool = True,
     ):
@@ -134,6 +137,13 @@ class KFACLinearOperator(_LinearOperator):
             mc_samples: The number of Monte-Carlo samples to use per data point.
                 Has to be set to ``1`` when ``fisher_type != 'mc'``.
                 Defaults to ``1``.
+            kfac_approx: A string specifying the KFAC approximation that should
+                be used for linear weight-sharing layers, e.g. `Conv2d` modules
+                or `Linear` modules that process matrix- or higher-dimensional
+                features.
+                Possible values are ``'expand'`` and ``'reduce'``.
+                See [Eschenhagen et al., 2023](https://arxiv.org/abs/2311.00636)
+                for an explanation of the two approximations.
             loss_average: Whether the loss function is a mean over per-sample
                 losses and if yes, over which dimensions the mean is taken.
                 If `"batch"`, the loss function is a mean over as many terms as
@@ -148,6 +158,10 @@ class KFACLinearOperator(_LinearOperator):
 
         Raises:
             ValueError: If the loss function is not supported.
+            ValueError: If the loss average is not supported.
+            ValueError: If the loss average is ``None`` and the loss function's
+                reduction is not ``'sum'``.
+            ValueError: If ``fisher_type != 'mc'`` and ``mc_samples != 1``.
             NotImplementedError: If a parameter is in an unsupported layer.
         """
         if not isinstance(loss_func, self._SUPPORTED_LOSSES):
@@ -164,10 +178,23 @@ class KFACLinearOperator(_LinearOperator):
                 f"Invalid loss_average: {loss_average}. "
                 f"Must be 'batch' or 'batch+sequence' if loss_func.reduction != 'sum'."
             )
+        if loss_func.reduction == "sum" and loss_average is not None:
+            # reduction used in loss function will overwrite loss_average
+            warnings.warn(
+                f"Loss function uses reduction='sum', but loss_average={loss_average}."
+                " loss_average is set to None.",
+                stacklevel=2,
+            )
+            loss_average = None
         if fisher_type != "mc" and mc_samples != 1:
             raise ValueError(
                 f"Invalid mc_samples: {mc_samples}. "
                 "Only mc_samples=1 is supported for fisher_type != 'mc'."
+            )
+        if kfac_approx not in self._SUPPORTED_KFAC_APPROX:
+            raise ValueError(
+                f"Invalid kfac_approx: {kfac_approx}. "
+                f"Supported: {self._SUPPORTED_KFAC_APPROX}."
             )
 
         self.param_ids = [p.data_ptr() for p in params]
@@ -192,6 +219,7 @@ class KFACLinearOperator(_LinearOperator):
         self._separate_weight_and_bias = separate_weight_and_bias
         self._fisher_type = fisher_type
         self._mc_samples = mc_samples
+        self._kfac_approx = kfac_approx
         self._loss_average = loss_average
         self._input_covariances: Dict[str, Tensor] = {}
         self._gradient_covariances: Dict[str, Tensor] = {}
@@ -443,22 +471,27 @@ class KFACLinearOperator(_LinearOperator):
             NotImplementedError: If the layer is not supported.
         """
         g = grad_output.data.detach()
+        num_loss_terms = g.shape[0]  # batch_size
         sequence_length = g.shape[1:-1].numel()
-        if self._loss_average is not None:
-            num_loss_terms = g.shape[0]  # batch_size
-            if self._loss_average == "batch+sequence":
-                # Number of all loss terms = batch_size * sequence_length
-                num_loss_terms *= sequence_length
+        if self._loss_average == "batch+sequence":
+            # Number of all loss terms = batch_size * sequence_length
+            num_loss_terms *= sequence_length
 
-        g = rearrange(g, "batch ... d_out -> (batch ...) d_out")
+        if self._kfac_approx == "expand":
+            # KFAC-expand approximation
+            g = rearrange(g, "batch ... d_out -> (batch ...) d_out")
+        else:
+            # KFAC-reduce approximation
+            g = reduce(g, "batch ... d_out -> batch d_out", "sum")
 
         if isinstance(module, Linear):
             # self._mc_samples will be 1 if fisher_type != "mc"
             correction = {
-                "sum": 1.0 / self._mc_samples,
-                "mean": num_loss_terms**2
+                None: 1.0 / self._mc_samples,
+                "batch": num_loss_terms**2 / (self._N_data * self._mc_samples),
+                "batch+sequence": num_loss_terms**2
                 / (self._N_data * self._mc_samples * sequence_length),
-            }[self._loss_func.reduction]
+            }[self._loss_average]
             covariance = einsum("bi,bj->ij", g, g).mul_(correction)
         else:
             # TODO Support convolutions
@@ -490,9 +523,15 @@ class KFACLinearOperator(_LinearOperator):
         if len(inputs) != 1:
             raise ValueError("Modules with multiple inputs are not supported.")
         x = inputs[0].data.detach()
-        sequence_length = x.shape[1:-1].numel()
 
-        x = rearrange(x, "batch ... d_in -> (batch ...) d_in")
+        if self._kfac_approx == "expand":
+            # KFAC-expand approximation
+            scale = x.shape[1:-1].numel()  # sequence_length
+            x = rearrange(x, "batch ... d_in -> (batch ...) d_in")
+        else:
+            # KFAC-reduce approximation
+            scale = 1.0  # since we use a mean reduction
+            x = reduce(x, "batch ... d_in -> batch d_in", "mean")
 
         if isinstance(module, Linear):
             if (
@@ -500,8 +539,7 @@ class KFACLinearOperator(_LinearOperator):
                 and not self._separate_weight_and_bias
             ):
                 x = cat([x, x.new_ones(x.shape[0], 1)], dim=1)
-
-            covariance = einsum("bi,bj->ij", x, x).div_(self._N_data * sequence_length)
+            covariance = einsum("bi,bj->ij", x, x).div_(self._N_data * scale)
         else:
             # TODO Support convolutions
             raise NotImplementedError(f"Layer of type {type(module)} is unsupported.")

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -152,7 +152,7 @@ class KFACLinearOperator(_LinearOperator):
                 or ``Linear`` modules that process matrix- or higher-dimensional
                 features.
                 Possible values are ``'expand'`` and ``'reduce'``.
-                See `Eschenhagen et al., 2023 <https://arxiv.org/abs/2311.00636>`_ 
+                See `Eschenhagen et al., 2023 <https://arxiv.org/abs/2311.00636>`_
                 for an explanation of the two approximations.
             loss_average: Whether the loss function is a mean over per-sample
                 losses and if yes, over which dimensions the mean is taken.
@@ -483,11 +483,13 @@ class KFACLinearOperator(_LinearOperator):
             NotImplementedError: If the layer is not supported.
         """
         g = grad_output.data.detach()
-        num_loss_terms = g.shape[0]  # batch_size
+        batch_size = g.shape[0]
         sequence_length = g.shape[1:-1].numel()
-        if self._loss_average == "batch+sequence":
-            # Number of all loss terms = batch_size * sequence_length
-            num_loss_terms *= sequence_length
+        num_loss_terms = {
+            None: batch_size,
+            "batch": batch_size,
+            "batch+sequence": batch_size * sequence_length,
+        }[self._loss_average]
 
         if self._kfac_approx == "expand":
             # KFAC-expand approximation

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -71,6 +71,11 @@ class KFACLinearOperator(_LinearOperator):
 
     _SUPPORTED_LOSSES = (MSELoss, CrossEntropyLoss)
     _SUPPORTED_MODULES = (Linear,)
+    _SUPPORTED_LOSS_AVERAGE: Tuple[Union[None, str], ...] = (
+        None,
+        "batch",
+        "batch+sequence",
+    )
 
     def __init__(
         self,
@@ -84,6 +89,7 @@ class KFACLinearOperator(_LinearOperator):
         seed: int = 2147483647,
         fisher_type: str = "mc",
         mc_samples: int = 1,
+        loss_average: Union[None, str] = "batch",
         separate_weight_and_bias: bool = True,
     ):
         """Kronecker-factored approximate curvature (KFAC) proxy of the Fisher/GGN.
@@ -128,6 +134,15 @@ class KFACLinearOperator(_LinearOperator):
             mc_samples: The number of Monte-Carlo samples to use per data point.
                 Has to be set to ``1`` when ``fisher_type != 'mc'``.
                 Defaults to ``1``.
+            loss_average: Whether the loss function is a mean over per-sample
+                losses and if yes, over which dimensions the mean is taken.
+                If `"batch"`, the loss function is a mean over as many terms as
+                the size of the mini-batch. If `"batch+sequence"`, the loss
+                function is a mean over as many terms as the size of the
+                mini-batch times the sequence length, e.g. in the case of
+                language modeling. If `None`, the loss function is a sum. This
+                argument is used to ensure that the preconditioner is scaled
+                consistently with the loss and the gradient. Default: `"batch"`.
             separate_weight_and_bias: Whether to treat weights and biases separately.
                 Defaults to ``True``.
 
@@ -138,6 +153,16 @@ class KFACLinearOperator(_LinearOperator):
         if not isinstance(loss_func, self._SUPPORTED_LOSSES):
             raise ValueError(
                 f"Invalid loss: {loss_func}. Supported: {self._SUPPORTED_LOSSES}."
+            )
+        if loss_average not in self._SUPPORTED_LOSS_AVERAGE:
+            raise ValueError(
+                f"Invalid loss_average: {loss_average}. "
+                f"Supported: {self._SUPPORTED_LOSS_AVERAGE}."
+            )
+        if loss_average is None and loss_func.reduction != "sum":
+            raise ValueError(
+                f"Invalid loss_average: {loss_average}. "
+                f"Must be 'batch' or 'batch+sequence' if loss_func.reduction != 'sum'."
             )
         if fisher_type != "mc" and mc_samples != 1:
             raise ValueError(
@@ -167,6 +192,7 @@ class KFACLinearOperator(_LinearOperator):
         self._separate_weight_and_bias = separate_weight_and_bias
         self._fisher_type = fisher_type
         self._mc_samples = mc_samples
+        self._loss_average = loss_average
         self._input_covariances: Dict[str, Tensor] = {}
         self._gradient_covariances: Dict[str, Tensor] = {}
 
@@ -284,14 +310,17 @@ class KFACLinearOperator(_LinearOperator):
         Raises:
             ValueError: If ``fisher_type`` is not ``'type-2'``, ``'mc'``, or
                 ``'empirical'``.
-            NotImplementedError: If ``fisher_type`` is ``'type-2'`` and the
-                output is not 2d.
         """
+        # if >2d output we convert to an equivalent 2d output
+        if output.ndim > 2:
+            if isinstance(self._loss_func, CrossEntropyLoss):
+                output = rearrange(output, "batch c ... -> (batch ...) c")
+                y = rearrange(y, "batch ... -> (batch ...)")
+            else:
+                output = rearrange(output, "batch ... c -> (batch ...) c")
+                y = rearrange(y, "batch ... c -> (batch ...) c")
+
         if self._fisher_type == "type-2":
-            if output.ndim != 2:
-                raise NotImplementedError(
-                    "Type-2 Fisher not implemented for non-2d output."
-                )
             # Compute per-sample Hessian square root, then concatenate over samples.
             # Result has shape `(batch_size, num_classes, num_classes)`
             hessian_sqrts = stack(
@@ -365,20 +394,12 @@ class KFACLinearOperator(_LinearOperator):
             return output.clone().detach() + perturbation
 
         elif isinstance(self._loss_func, CrossEntropyLoss):
-            # TODO For output.ndim > 2, the scale of the 'would-be' gradient resulting
-            # from these labels might be off
-            if output.ndim != 2:
-                raise NotImplementedError(
-                    "Only 2D output is supported for CrossEntropyLoss for now."
-                )
-            probs = output.softmax(dim=1)
             # each row contains a vector describing a categorical
-            probs_as_mat = rearrange(probs, "n c ... -> (n ...) c")
-            labels = probs_as_mat.multinomial(
+            probs = output.softmax(dim=1)
+            labels = probs.multinomial(
                 num_samples=1, generator=self._generator
             ).squeeze(-1)
-            label_shape = output.shape[:1] + output.shape[2:]
-            return labels.reshape(label_shape)
+            return labels
 
         else:
             raise NotImplementedError
@@ -422,20 +443,21 @@ class KFACLinearOperator(_LinearOperator):
             NotImplementedError: If the layer is not supported.
         """
         g = grad_output.data.detach()
+        sequence_length = g.shape[1:-1].numel()
+        if self._loss_average is not None:
+            num_loss_terms = g.shape[0]  # batch_size
+            if self._loss_average == "batch+sequence":
+                # Number of all loss terms = batch_size * sequence_length
+                num_loss_terms *= sequence_length
+
+        g = rearrange(g, "batch ... d_out -> (batch ...) d_out")
 
         if isinstance(module, Linear):
-            if g.ndim != 2:
-                # TODO Support weight sharing
-                raise NotImplementedError(
-                    "Only 2d grad_outputs are supported for linear layers. "
-                    + f"Got {g.ndim}d."
-                )
-
-            batch_size = g.shape[0]
             # self._mc_samples will be 1 if fisher_type != "mc"
             correction = {
                 "sum": 1.0 / self._mc_samples,
-                "mean": batch_size**2 / (self._N_data * self._mc_samples),
+                "mean": num_loss_terms**2
+                / (self._N_data * self._mc_samples * sequence_length),
             }[self._loss_func.reduction]
             covariance = einsum("bi,bj->ij", g, g).mul_(correction)
         else:
@@ -468,21 +490,18 @@ class KFACLinearOperator(_LinearOperator):
         if len(inputs) != 1:
             raise ValueError("Modules with multiple inputs are not supported.")
         x = inputs[0].data.detach()
+        sequence_length = x.shape[1:-1].numel()
+
+        x = rearrange(x, "batch ... d_in -> (batch ...) d_in")
 
         if isinstance(module, Linear):
-            if x.ndim != 2:
-                # TODO Support weight sharing
-                raise NotImplementedError(
-                    f"Only 2d inputs are supported for linear layers. Got {x.ndim}d."
-                )
-
             if (
                 self.in_params(module.weight, module.bias)
                 and not self._separate_weight_and_bias
             ):
                 x = cat([x, x.new_ones(x.shape[0], 1)], dim=1)
 
-            covariance = einsum("bi,bj->ij", x, x).div_(self._N_data)
+            covariance = einsum("bi,bj->ij", x, x).div_(self._N_data * sequence_length)
         else:
             # TODO Support convolutions
             raise NotImplementedError(f"Layer of type {type(module)} is unsupported.")

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -525,7 +525,6 @@ class KFACLinearOperator(_LinearOperator):
         if len(inputs) != 1:
             raise ValueError("Modules with multiple inputs are not supported.")
         x = inputs[0].data.detach()
-        sequence_length = x.shape[1:-1].numel()
 
         if self._kfac_approx == "expand":
             # KFAC-expand approximation

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -60,15 +60,20 @@ class KFACLinearOperator(_LinearOperator):
     'would-be' gradients w.r.t. the layer's output. Those 'would-be' gradients result
     from sampling labels from the model's distribution and computing their gradients.
 
-    The basic version of KFAC for MLPs was introduced in
+    Kronecker-Factored Approximate Curvature (KFAC) was originally introduced for MLPs in
 
-    - Martens, J., & Grosse, R. (2015). Optimizing neural networks with
-      Kronecker-factored approximate curvature. ICML.
+    - Martens, J., & Grosse, R. (2015). Optimizing neural networks with Kronecker-factored
+    approximate curvature. International Conference on Machine Learning (ICML),
 
-    and later generalized to convolutions in
+    extended to CNNs in
 
-    - Grosse, R., & Martens, J. (2016). A kronecker-factored approximate Fisher
-      matrix for convolution layers. ICML.
+    - Grosse, R., & Martens, J. (2016). A kronecker-factored approximate Fisher matrix for
+    convolution layers. International Conference on Machine Learning (ICML),
+
+    and generalized to all linear layers with weight sharing in
+
+    - Eschenhagen, R., Immer, A., Turner, R. E., Schneider, F., Hennig, P. (2023).
+    Kronecker-Factored Approximate Curvature for Modern Neural Network Architectures (NeurIPS).
 
     Attributes:
         _SUPPORTED_LOSSES: Tuple of supported loss functions.
@@ -143,21 +148,21 @@ class KFACLinearOperator(_LinearOperator):
                 Has to be set to ``1`` when ``fisher_type != 'mc'``.
                 Defaults to ``1``.
             kfac_approx: A string specifying the KFAC approximation that should
-                be used for linear weight-sharing layers, e.g. `Conv2d` modules
-                or `Linear` modules that process matrix- or higher-dimensional
+                be used for linear weight-sharing layers, e.g. ``Conv2d`` modules
+                or ``Linear`` modules that process matrix- or higher-dimensional
                 features.
                 Possible values are ``'expand'`` and ``'reduce'``.
-                See [Eschenhagen et al., 2023](https://arxiv.org/abs/2311.00636)
+                See `Eschenhagen et al., 2023 <https://arxiv.org/abs/2311.00636>`_ 
                 for an explanation of the two approximations.
             loss_average: Whether the loss function is a mean over per-sample
                 losses and if yes, over which dimensions the mean is taken.
-                If `"batch"`, the loss function is a mean over as many terms as
-                the size of the mini-batch. If `"batch+sequence"`, the loss
+                If ``"batch"``, the loss function is a mean over as many terms as
+                the size of the mini-batch. If ``"batch+sequence"``, the loss
                 function is a mean over as many terms as the size of the
                 mini-batch times the sequence length, e.g. in the case of
-                language modeling. If `None`, the loss function is a sum. This
+                language modeling. If ``None``, the loss function is a sum. This
                 argument is used to ensure that the preconditioner is scaled
-                consistently with the loss and the gradient. Default: `"batch"`.
+                consistently with the loss and the gradient. Default: ``"batch"``.
             separate_weight_and_bias: Whether to treat weights and biases separately.
                 Defaults to ``True``.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,11 @@
 """Contains pytest fixtures that are visible by other files."""
 
 from test.cases import ADJOINT_CASES, CASES, NON_DETERMINISTIC_CASES
-from test.kfac_cases import KFAC_EXPAND_EXACT_CASES, KFAC_EXPAND_EXACT_ONE_DATUM_CASES
+from test.kfac_cases import (
+    KFAC_EXACT_CASES,
+    KFAC_EXACT_ONE_DATUM_CASES,
+    KFAC_WEIGHT_SHARING_EXACT_CASES,
+)
 from typing import Callable, Dict, Iterable, List, Tuple
 
 from numpy import random
@@ -60,11 +64,11 @@ def adjoint(request) -> bool:
     return request.param
 
 
-@fixture(params=KFAC_EXPAND_EXACT_CASES)
-def kfac_expand_exact_case(
+@fixture(params=KFAC_EXACT_CASES)
+def kfac_exact_case(
     request,
 ) -> Tuple[Module, MSELoss, List[Tensor], Iterable[Tuple[Tensor, Tensor]],]:
-    """Prepare a test case for which KFAC-expand equals the GGN.
+    """Prepare a test case for which KFAC equals the GGN.
 
     Yields:
         A neural network, the mean-squared error function, a list of parameters, and
@@ -74,11 +78,25 @@ def kfac_expand_exact_case(
     yield initialize_case(case)
 
 
-@fixture(params=KFAC_EXPAND_EXACT_ONE_DATUM_CASES)
-def kfac_expand_exact_one_datum_case(
+@fixture(params=KFAC_WEIGHT_SHARING_EXACT_CASES)
+def kfac_weight_sharing_exact_case(
+    request,
+) -> Tuple[Module, MSELoss, List[Tensor], Iterable[Tuple[Tensor, Tensor]],]:
+    """Prepare a test case with weight-sharing for which KFAC equals the GGN.
+
+    Yields:
+        A neural network, the mean-squared error function, a list of parameters, and
+        a data set.
+    """
+    case = request.param
+    yield initialize_case(case)
+
+
+@fixture(params=KFAC_EXACT_ONE_DATUM_CASES)
+def kfac_exact_one_datum_case(
     request,
 ) -> Tuple[Module, Module, List[Tensor], Iterable[Tuple[Tensor, Tensor]],]:
-    """Prepare a test case for which KFAC-expand equals the GGN and one datum is used.
+    """Prepare a test case for which KFAC equals the GGN and one datum is used.
 
     Yields:
         A neural network, loss function, a list of parameters, and

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -11,7 +11,6 @@ from test.utils import (
 from torch import rand
 from torch.nn import CrossEntropyLoss, Linear, MSELoss, Sequential
 
-
 # Add test cases here, devices and loss function with different reductions will be
 # added automatically below
 KFAC_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -1,14 +1,20 @@
 """Contains test cases for the KFAC linear operator."""
 
 from functools import partial
-from test.utils import classification_targets, get_available_devices, regression_targets
+from test.utils import (
+    WeightShareModel,
+    classification_targets,
+    get_available_devices,
+    regression_targets,
+)
 
 from torch import rand
 from torch.nn import CrossEntropyLoss, Linear, MSELoss, Sequential
 
+
 # Add test cases here, devices and loss function with different reductions will be
 # added automatically below
-KFAC_EXPAND_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [
+KFAC_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [
     ###############################################################################
     #                                  REGRESSION                                 #
     ###############################################################################
@@ -32,8 +38,8 @@ KFAC_EXPAND_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [
     },
 ]
 
-KFAC_EXPAND_EXACT_CASES = []
-for case in KFAC_EXPAND_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC:
+KFAC_EXACT_CASES = []
+for case in KFAC_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC:
     for device in get_available_devices():
         for reduction in ["mean", "sum"]:
             case_with_device_and_loss_func = {
@@ -41,11 +47,50 @@ for case in KFAC_EXPAND_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC:
                 "device": device,
                 "loss_func": partial(MSELoss, reduction=reduction),
             }
-            KFAC_EXPAND_EXACT_CASES.append(case_with_device_and_loss_func)
+            KFAC_EXACT_CASES.append(case_with_device_and_loss_func)
+
+
+# Add test cases here, devices and loss function with different reductions will be
+# added automatically below
+KFAC_WEIGHT_SHARING_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [
+    ###############################################################################
+    #                                  REGRESSION                                 #
+    ###############################################################################
+    # deep linear network with vector output and weight-sharing dimensions
+    {
+        "model_func": lambda: WeightShareModel(Linear(5, 4), Linear(4, 3)),
+        "data": lambda: {
+            # exactess with expand requires that the product of all
+            # weight-sharing dimension sizes is the same in all batches
+            # (e.g. 32 = 4 * 8)
+            "expand": [
+                (rand(2, 32, 5), regression_targets((2, 32, 3))),
+                (rand(7, 4, 8, 5), regression_targets((7, 4, 8, 3))),
+            ],
+            # for reduce it works with arbitrary weight-sharing dims per batch
+            "reduce": [
+                (rand(1, 4, 5), regression_targets((1, 3))),
+                (rand(7, 4, 8, 5), regression_targets((7, 3))),
+            ],
+        },
+        "seed": 0,
+    },
+]
+
+KFAC_WEIGHT_SHARING_EXACT_CASES = []
+for case in KFAC_WEIGHT_SHARING_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC:
+    for device in get_available_devices():
+        for reduction in ["mean", "sum"]:
+            case_with_device_and_loss_func = {
+                **case,
+                "device": device,
+                "loss_func": partial(MSELoss, reduction=reduction),
+            }
+            KFAC_WEIGHT_SHARING_EXACT_CASES.append(case_with_device_and_loss_func)
 
 
 # Add test cases here, devices will be added automatically below
-KFAC_EXPAND_EXACT_ONE_DATUM_CASES_NO_DEVICE = [
+KFAC_EXACT_ONE_DATUM_CASES_NO_DEVICE = [
     ###############################################################################
     #                                CLASSIFICATION                               #
     ###############################################################################
@@ -64,11 +109,11 @@ KFAC_EXPAND_EXACT_ONE_DATUM_CASES_NO_DEVICE = [
     },
 ]
 
-KFAC_EXPAND_EXACT_ONE_DATUM_CASES = []
-for case in KFAC_EXPAND_EXACT_ONE_DATUM_CASES_NO_DEVICE:
+KFAC_EXACT_ONE_DATUM_CASES = []
+for case in KFAC_EXACT_ONE_DATUM_CASES_NO_DEVICE:
     for device in get_available_devices():
         case_with_device = {
             **case,
             "device": device,
         }
-        KFAC_EXPAND_EXACT_ONE_DATUM_CASES.append(case_with_device)
+        KFAC_EXACT_ONE_DATUM_CASES.append(case_with_device)

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -59,16 +59,12 @@ KFAC_WEIGHT_SHARING_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [
     {
         "model_func": lambda: WeightShareModel(Linear(5, 4), Linear(4, 3)),
         "data": lambda: {
-            # exactess with expand requires that the product of all
-            # weight-sharing dimension sizes is the same in all batches
-            # (e.g. 32 = 4 * 8)
             "expand": [
-                (rand(2, 32, 5), regression_targets((2, 32, 3))),
+                (rand(2, 4, 8, 5), regression_targets((2, 4, 8, 3))),
                 (rand(7, 4, 8, 5), regression_targets((7, 4, 8, 3))),
             ],
-            # for reduce it works with arbitrary weight-sharing dims per batch
             "reduce": [
-                (rand(1, 4, 5), regression_targets((1, 3))),
+                (rand(1, 4, 8, 5), regression_targets((1, 3))),
                 (rand(7, 4, 8, 5), regression_targets((7, 3))),
             ],
         },

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -3,11 +3,12 @@
 from test.cases import DEVICES, DEVICES_IDS
 from test.utils import (
     Rearrange,
+    WeightShareModel,
     classification_targets,
     ggn_block_diagonal,
     regression_targets,
 )
-from typing import Iterable, List, Tuple, Union
+from typing import Dict, Iterable, List, Tuple, Union
 
 from numpy import eye
 from pytest import mark
@@ -37,7 +38,7 @@ from curvlinops.kfac import KFACLinearOperator
 )
 @mark.parametrize("shuffle", [False, True], ids=["", "shuffled"])
 def test_kfac_type2(
-    kfac_expand_exact_case: Tuple[
+    kfac_exact_case: Tuple[
         Module, MSELoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
     ],
     shuffle: bool,
@@ -47,7 +48,7 @@ def test_kfac_type2(
     """Test the KFAC implementation against the exact GGN.
 
     Args:
-        kfac_expand_exact_case: A fixture that returns a model, loss function, list of
+        kfac_exact_case: A fixture that returns a model, loss function, list of
             parameters, and data.
         shuffle: Whether to shuffle the parameters before computing the KFAC matrix.
         exclude: Which parameters to exclude. Can be ``'weight'``, ``'bias'``,
@@ -56,7 +57,7 @@ def test_kfac_type2(
             the KFAC matrix.
     """
     assert exclude in [None, "weight", "bias"]
-    model, loss_func, params, data = kfac_expand_exact_case
+    model, loss_func, params, data = kfac_exact_case
 
     if exclude is not None:
         names = {p.data_ptr(): name for name, p in model.named_parameters()}
@@ -90,9 +91,89 @@ def test_kfac_type2(
         assert len(kfac._input_covariances) == 0
 
 
+@mark.parametrize("setting", ["expand", "reduce"])
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
+@mark.parametrize(
+    "exclude", [None, "weight", "bias"], ids=["all", "no_weights", "no_biases"]
+)
+@mark.parametrize("shuffle", [False, True], ids=["", "shuffled"])
+def test_kfac_type2_weight_sharing(
+    kfac_weight_sharing_exact_case: Tuple[
+        WeightShareModel,
+        MSELoss,
+        List[Parameter],
+        Dict[str, Iterable[Tuple[Tensor, Tensor]]],
+    ],
+    setting: str,
+    shuffle: bool,
+    exclude: str,
+    separate_weight_and_bias: bool,
+):
+    """Test KFAC for linear weight-sharing layers against the exact GGN.
+
+    Args:
+        kfac_weight_sharing_exact_case: A fixture that returns a model, loss function, list of
+            parameters, and data.
+        setting: The weight-sharing setting to use. Can be ``'expand'`` or ``'reduce'``.
+        shuffle: Whether to shuffle the parameters before computing the KFAC matrix.
+        exclude: Which parameters to exclude. Can be ``'weight'``, ``'bias'``,
+            or ``None``.
+        separate_weight_and_bias: Whether to treat weight and bias as separate blocks in
+            the KFAC matrix.
+    """
+    assert exclude in [None, "weight", "bias"]
+    model, loss_func, params, data = kfac_weight_sharing_exact_case
+    model.setting = setting
+    data = data[setting]
+
+    # set appropriate loss_average argument based on loss reduction and setting
+    if loss_func.reduction == "mean":
+        if setting == "expand":
+            loss_average = "batch+sequence"
+        else:
+            loss_average = "batch"
+    else:
+        loss_average = None
+
+    if exclude is not None:
+        names = {p.data_ptr(): name for name, p in model.named_parameters()}
+        params = [p for p in params if exclude not in names[p.data_ptr()]]
+
+    if shuffle:
+        permutation = randperm(len(params))
+        params = [params[i] for i in permutation]
+
+    ggn = ggn_block_diagonal(
+        model,
+        loss_func,
+        params,
+        data,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+    kfac = KFACLinearOperator(
+        model,
+        loss_func,
+        params,
+        data,
+        fisher_type="type-2",
+        kfac_approx=setting,  # choose KFAC approximation consistent with setting
+        loss_average=loss_average,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+    kfac_mat = kfac @ eye(kfac.shape[1])
+
+    report_nonclose(ggn, kfac_mat)
+
+    # Check that input covariances were not computed
+    if exclude == "weight":
+        assert len(kfac._input_covariances) == 0
+
+
 @mark.parametrize("shuffle", [False, True], ids=["", "shuffled"])
 def test_kfac_mc(
-    kfac_expand_exact_case: Tuple[
+    kfac_exact_case: Tuple[
         Module, MSELoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
     ],
     shuffle: bool,
@@ -100,11 +181,11 @@ def test_kfac_mc(
     """Test the KFAC implementation using MC samples against the exact GGN.
 
     Args:
-        kfac_expand_exact_case: A fixture that returns a model, loss function, list of
+        kfac_exact_case: A fixture that returns a model, loss function, list of
             parameters, and data.
         shuffle: Whether to shuffle the parameters before computing the KFAC matrix.
     """
-    model, loss_func, params, data = kfac_expand_exact_case
+    model, loss_func, params, data = kfac_exact_case
 
     if shuffle:
         permutation = randperm(len(params))
@@ -122,11 +203,11 @@ def test_kfac_mc(
 
 
 def test_kfac_one_datum(
-    kfac_expand_exact_one_datum_case: Tuple[
+    kfac_exact_one_datum_case: Tuple[
         Module, CrossEntropyLoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
     ]
 ):
-    model, loss_func, params, data = kfac_expand_exact_one_datum_case
+    model, loss_func, params, data = kfac_exact_one_datum_case
 
     ggn = ggn_block_diagonal(model, loss_func, params, data)
     kfac = KFACLinearOperator(model, loss_func, params, data, fisher_type="type-2")
@@ -136,11 +217,11 @@ def test_kfac_one_datum(
 
 
 def test_kfac_mc_one_datum(
-    kfac_expand_exact_one_datum_case: Tuple[
+    kfac_exact_one_datum_case: Tuple[
         Module, CrossEntropyLoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
     ]
 ):
-    model, loss_func, params, data = kfac_expand_exact_one_datum_case
+    model, loss_func, params, data = kfac_exact_one_datum_case
     ggn = ggn_block_diagonal(model, loss_func, params, data)
 
     kfac = KFACLinearOperator(model, loss_func, params, data, mc_samples=10_000)
@@ -153,11 +234,11 @@ def test_kfac_mc_one_datum(
 
 
 def test_kfac_ef_one_datum(
-    kfac_expand_exact_one_datum_case: Tuple[
+    kfac_exact_one_datum_case: Tuple[
         Module, CrossEntropyLoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
     ]
 ):
-    model, loss_func, params, data = kfac_expand_exact_one_datum_case
+    model, loss_func, params, data = kfac_exact_one_datum_case
 
     ef_blocks = []  # list of per-parameter EFs
     for param in params:

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -1,8 +1,13 @@
 """Contains tests for ``curvlinops.kfac``."""
 
 from test.cases import DEVICES, DEVICES_IDS
-from test.utils import ggn_block_diagonal, regression_targets
-from typing import Iterable, List, Tuple
+from test.utils import (
+    Rearrange,
+    classification_targets,
+    ggn_block_diagonal,
+    regression_targets,
+)
+from typing import Iterable, List, Tuple, Union
 
 from numpy import eye
 from pytest import mark
@@ -10,6 +15,7 @@ from scipy.linalg import block_diag
 from torch import Tensor, device, manual_seed, rand, randperm
 from torch.nn import (
     CrossEntropyLoss,
+    Flatten,
     Linear,
     Module,
     MSELoss,
@@ -200,3 +206,71 @@ def test_kfac_inplace_activations(dev: device):
     ggn_no_inplace = ggn_block_diagonal(model, loss_func, params, data)
 
     report_nonclose(ggn, ggn_no_inplace)
+
+
+@mark.parametrize("fisher_type", ["type-2", "mc", "empirical"])
+@mark.parametrize("loss", [MSELoss, CrossEntropyLoss], ids=["mse", "ce"])
+@mark.parametrize("reduction", ["mean", "sum"])
+@mark.parametrize("dev", DEVICES, ids=DEVICES_IDS)
+def test_multi_dim_output(
+    fisher_type: str,
+    loss: Union[MSELoss, CrossEntropyLoss],
+    reduction: str,
+    dev: device,
+):
+    """Test the KFAC implementation for >2d outputs (using a 3d and 4d output).
+
+    Args:
+        fisher_type: The type of Fisher matrix to use.
+        loss: The loss function to use.
+        reduction: The reduction to use for the loss function.
+        dev: The device to run the test on.
+    """
+    manual_seed(0)
+    # set up loss function, data, and model
+    loss_func = loss(reduction=reduction).to(dev)
+    if isinstance(loss_func, MSELoss):
+        data = [
+            (rand(2, 4, 5), regression_targets((2, 4, 3))),
+            (rand(4, 7, 5, 5), regression_targets((4, 7, 5, 3))),
+        ]
+        manual_seed(711)
+        model = Sequential(Linear(5, 4), Linear(4, 3)).to(dev)
+    else:
+        data = [
+            (rand(2, 4, 5), classification_targets((2, 4), 3)),
+            (rand(4, 7, 5, 5), classification_targets((4, 7, 5), 3)),
+        ]
+        manual_seed(711)
+        # rearrange is necessary to get the expected output shape for ce loss
+        model = Sequential(
+            Linear(5, 4),
+            Linear(4, 3),
+            Rearrange("batch ... c -> batch c ..."),
+        ).to(dev)
+
+    # KFAC for deep linear network with 3d/4d input and output
+    params = list(model.parameters())
+    kfac = KFACLinearOperator(model, loss_func, params, data, fisher_type=fisher_type)
+    kfac_mat = kfac @ eye(kfac.shape[1])
+
+    # KFAC for deep linear network with 3d/4d input and equivalent 2d output
+    manual_seed(711)
+    model_flat = Sequential(
+        Linear(5, 4),
+        Linear(4, 3),
+        Flatten(start_dim=0, end_dim=-2),
+    ).to(dev)
+    params_flat = list(model_flat.parameters())
+    data_flat = [
+        (x, y.flatten(start_dim=0, end_dim=-2))
+        if isinstance(loss_func, MSELoss)
+        else (x, y.flatten(start_dim=0))
+        for x, y in data
+    ]
+    kfac_flat = KFACLinearOperator(
+        model_flat, loss_func, params_flat, data_flat, fisher_type=fisher_type
+    )
+    kfac_flat_mat = kfac_flat @ eye(kfac_flat.shape[1])
+
+    report_nonclose(kfac_mat, kfac_flat_mat)

--- a/test/utils.py
+++ b/test/utils.py
@@ -3,6 +3,7 @@
 from itertools import product
 from typing import Iterable, List, Tuple
 
+from einops import rearrange
 from numpy import eye, ndarray
 from torch import Tensor, cat, cuda, device, from_numpy, rand, randint
 from torch.nn import Module, Parameter
@@ -24,13 +25,28 @@ def get_available_devices():
     return devices
 
 
-def classification_targets(size, num_classes):
-    """Create random targets for classes 0, ..., `num_classes - 1`."""
+def classification_targets(size: Tuple[int], num_classes: int) -> Tensor:
+    """Create random targets for classes 0, ..., `num_classes - 1`.
+    
+    Args:
+        size: Size of the targets to create.
+        num_classes: Number of classes.
+
+    Returns:
+        Random targets.
+    """
     return randint(size=size, low=0, high=num_classes)
 
 
-def regression_targets(size):
-    """Create random targets for regression."""
+def regression_targets(size: Tuple[int]) -> Tensor:
+    """Create random targets for regression.
+    
+    Args:
+        size: Size of the targets to create.
+    
+    Returns:
+        Random targets.
+    """
     return rand(*size)
 
 
@@ -91,3 +107,27 @@ def ggn_block_diagonal(
 
     # concatenate all blocks
     return cat([cat(row_blocks, dim=1) for row_blocks in ggn_blocks], dim=0).numpy()
+
+
+class Rearrange(Module):
+    """A module that rearranges the input tensor."""
+
+    def __init__(self, pattern: str):
+        """Initialize the module.
+
+        Args:
+            pattern: The rearrangement pattern.
+        """
+        super().__init__()
+        self.pattern = pattern
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Rearrange the input tensor.
+
+        Args:
+            x: The input tensor.
+
+        Returns:
+            The rearranged tensor.
+        """
+        return rearrange(x, self.pattern)

--- a/test/utils.py
+++ b/test/utils.py
@@ -11,11 +11,11 @@ from torch.nn import Module, Parameter, Sequential
 from curvlinops import GGNLinearOperator
 
 
-def get_available_devices():
+def get_available_devices() -> List[device]:
     """Return CPU and, if present, GPU device.
 
     Returns:
-        [device]: Available devices for ``torch``.
+        devices: Available devices for ``torch``.
     """
     devices = [device("cpu")]
 
@@ -118,7 +118,7 @@ class WeightShareModel(Sequential):
     ``(batch, ..., out_dim)``.
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args: Module):
         """Initialize the model.
 
         Args:

--- a/test/utils.py
+++ b/test/utils.py
@@ -3,10 +3,10 @@
 from itertools import product
 from typing import Iterable, List, Tuple
 
-from einops import rearrange
+from einops import rearrange, reduce
 from numpy import eye, ndarray
 from torch import Tensor, cat, cuda, device, from_numpy, rand, randint
-from torch.nn import Module, Parameter
+from torch.nn import Module, Parameter, Sequential
 
 from curvlinops import GGNLinearOperator
 
@@ -131,3 +131,75 @@ class Rearrange(Module):
             The rearranged tensor.
         """
         return rearrange(x, self.pattern)
+
+
+class WeightShareModel(Sequential):
+    """Sequential model with processing of the weight-sharing dimension.
+
+    Wraps a `Sequential` model, but processes the weight-sharing dimension based
+    on the `setting` before it returns the output of the sequential model.
+    Assumes that the output of the sequential model is of shape
+    (batch, ..., out_dim).
+    """
+
+    def __init__(self, *args):
+        """Initialize the model.
+
+        Args:
+            *args: Modules of the sequential model.
+        """
+        super().__init__(*args)
+        self._setting = None
+
+    @property
+    def setting(self) -> str:
+        """Return the setting of the model.
+
+        Returns:
+            The setting of the model.
+
+        Raises:
+            ValueError: If `setting` property has not been set.
+        """
+        if self._setting is None:
+            raise ValueError("WeightShareModel.setting has not been set.")
+        return self._setting
+
+    @setting.setter
+    def setting(self, setting: str):
+        """Set the weight-sharing setting of the model.
+
+        Args:
+            setting: The weight-sharing setting of the model.
+
+        Raises:
+            ValueError: If `setting` is neither `'expand'` nor `'reduce'`.
+        """
+        if setting not in {"expand", "reduce"}:
+            raise ValueError(
+                f"Expected 'setting' to be 'expand' or 'reduce', got {setting}."
+            )
+        self._setting = setting
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass with processing of the weight-sharing dimension.
+
+        Assumes MSELoss. The output would have to be transposed to be used with
+        the CrossEntropyLoss.
+
+        Args:
+            x: Input to the forward pass.
+
+        Returns:
+            Output of the sequential model with processed weight-sharing dimension.
+        """
+        x = super().forward(x)
+        if self.setting == "reduce":
+            # Example: Vision transformer for image classification.
+            # (batch, image_patches, c) -> (batch, c)
+            return reduce(x, "batch ... c -> batch c", "mean")
+        # if self.setting == "expand":
+        # Example: Transformer for translation: (batch, sequence_length, c)
+        # (although second and third dimension would have to be transposed for
+        # classification)
+        return x

--- a/test/utils.py
+++ b/test/utils.py
@@ -27,7 +27,7 @@ def get_available_devices():
 
 def classification_targets(size: Tuple[int], num_classes: int) -> Tensor:
     """Create random targets for classes 0, ..., `num_classes - 1`.
-    
+
     Args:
         size: Size of the targets to create.
         num_classes: Number of classes.
@@ -40,10 +40,10 @@ def classification_targets(size: Tuple[int], num_classes: int) -> Tensor:
 
 def regression_targets(size: Tuple[int]) -> Tensor:
     """Create random targets for regression.
-    
+
     Args:
         size: Size of the targets to create.
-    
+
     Returns:
         Random targets.
     """


### PR DESCRIPTION
Resolves #50.

This PR is based on #62 which should be reviewed first. I will tackle #45 next and directly implement expand and reduce (will reuse most of the code for linear modules since it is almost identical).