### PR TITLE
[ADD] Option to specify number of data points

### DIFF
--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -84,9 +84,9 @@ class _LinearOperator(LinearOperator):
         self._progressbar = progressbar
 
         self._N_data = (
-            num_data
-            if num_data is not None
-            else sum(X.shape[0] for (X, _) in self._loop_over_data(desc="_N_data"))
+            sum(X.shape[0] for (X, _) in self._loop_over_data(desc="_N_data"))
+            if num_data is None
+            else num_data
         )
 
         if check_deterministic:

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -38,6 +38,7 @@ class _LinearOperator(LinearOperator):
         progressbar: bool = False,
         check_deterministic: bool = True,
         shape: Optional[Tuple[int, int]] = None,
+        num_data: Optional[int] = None,
     ):
         """Linear operator for DNN matrices.
 
@@ -64,6 +65,8 @@ class _LinearOperator(LinearOperator):
                 safeguard, only turn it off if you know what you are doing.
             shape: Shape of the represented matrix. If ``None`` assumes ``(D, D)``
                 where ``D`` is the total number of parameters
+            num_data: Number of data points. If ``None``, it is inferred from the data
+                at the cost of one traversal through the data loader.
 
         Raises:
             RuntimeError: If the check for deterministic behavior fails.
@@ -80,8 +83,10 @@ class _LinearOperator(LinearOperator):
         self._device = self._infer_device(self._params)
         self._progressbar = progressbar
 
-        self._N_data = sum(
-            X.shape[0] for (X, _) in self._loop_over_data(desc="_N_data")
+        self._N_data = (
+            num_data
+            if num_data is not None
+            else sum(X.shape[0] for (X, _) in self._loop_over_data(desc="_N_data"))
         )
 
         if check_deterministic:

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import sqrt
-from typing import Callable, Iterable, List, Tuple, Union
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 from numpy import ndarray
 from torch import (
@@ -120,6 +120,7 @@ class FisherMCLinearOperator(_LinearOperator):
         check_deterministic: bool = True,
         seed: int = 2147483647,
         mc_samples: int = 1,
+        num_data: Optional[int] = None,
     ):
         """Linear operator for the MC approximation of the Fisher.
 
@@ -149,6 +150,8 @@ class FisherMCLinearOperator(_LinearOperator):
                 draw samples at the beginning of each matrix-vector product.
                 Default: ``2147483647``
             mc_samples: Number of samples to use. Default: ``1``.
+            num_data: Number of data points. If ``None``, it is inferred from the data
+                at the cost of one traversal through the data loader.
 
         Raises:
             NotImplementedError: If the loss function differs from ``MSELoss`` or
@@ -168,6 +171,7 @@ class FisherMCLinearOperator(_LinearOperator):
             data,
             progressbar=progressbar,
             check_deterministic=check_deterministic,
+            num_data=num_data,
         )
 
     def _matvec(self, x: ndarray) -> ndarray:

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from functools import partial
 from math import sqrt
-from typing import Dict, Iterable, List, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from einops import rearrange, reduce
 from numpy import ndarray
@@ -107,6 +107,7 @@ class KFACLinearOperator(_LinearOperator):
         kfac_approx: str = "expand",
         loss_average: Union[None, str] = "batch",
         separate_weight_and_bias: bool = True,
+        num_data: Optional[int] = None,
     ):
         """Kronecker-factored approximate curvature (KFAC) proxy of the Fisher/GGN.
 
@@ -165,6 +166,8 @@ class KFACLinearOperator(_LinearOperator):
                 consistently with the loss and the gradient. Default: ``"batch"``.
             separate_weight_and_bias: Whether to treat weights and biases separately.
                 Defaults to ``True``.
+            num_data: Number of data points. If ``None``, it is inferred from the data
+                at the cost of one traversal through the data loader.
 
         Raises:
             ValueError: If the loss function is not supported.
@@ -241,6 +244,7 @@ class KFACLinearOperator(_LinearOperator):
             progressbar=progressbar,
             check_deterministic=check_deterministic,
             shape=shape,
+            num_data=num_data,
         )
 
     def _matvec(self, x: ndarray) -> ndarray:


### PR DESCRIPTION
At the moment, the number of data points is inferred by a pass through the data loader.
This can become a bottleneck on compute clusters when multiple jobs access the same data set in parallel (experience from a recent ICML submission on the Vector cluster).
To resolve this, the PR adds an optional argument `num_data` to all non-experimental linear operators which allows to avoid the data set traversal.