### PR TITLE
[REF] Implement `_matmat` instead of `_matvec`

### DIFF
--- a/curvlinops/examples/utils.py
+++ b/curvlinops/examples/utils.py
@@ -24,7 +24,9 @@ def report_nonclose(
         ValueError: If the two arrays don't match in shape or have nonclose values.
     """
     if array1.shape != array2.shape:
-        raise ValueError("Arrays shapes don't match.")
+        raise ValueError(
+            f"Arrays shapes don't match:{array1.shape} vs. {array2.shape}."
+        )
 
     if allclose(array1, array2, rtol=rtol, atol=atol, equal_nan=equal_nan):
         print("Compared arrays match.")

--- a/curvlinops/examples/utils.py
+++ b/curvlinops/examples/utils.py
@@ -25,7 +25,7 @@ def report_nonclose(
     """
     if array1.shape != array2.shape:
         raise ValueError(
-            f"Arrays shapes don't match:{array1.shape} vs. {array2.shape}."
+            f"Arrays shapes don't match: {array1.shape} vs. {array2.shape}."
         )
 
     if allclose(array1, array2, rtol=rtol, atol=atol, equal_nan=equal_nan):

--- a/curvlinops/experimental/activation_hessian.py
+++ b/curvlinops/experimental/activation_hessian.py
@@ -6,7 +6,8 @@ from typing import Callable, Iterable, List, Optional, Set, Tuple, Type, Union
 
 from backpack.hessianfree.hvp import hessian_vector_product
 from numpy import ndarray
-from torch import Tensor, from_numpy
+from torch import Tensor, from_numpy, zeros_like
+from torch.autograd import grad
 from torch.nn import Module
 from torch.utils.hooks import RemovableHandle
 
@@ -129,36 +130,61 @@ class ActivationHessianLinearOperator(_LinearOperator):
             shape=shape,
         )
 
-    def _matvec_batch(
-        self, X: Tensor, y: Tensor, x_list: List[Tensor]
+    def _matmat_batch(
+        self, X: Tensor, y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
-        """Apply the mini-batch Hessian to a vector.
+        """Apply the activation Hessian to a matrix.
 
         Args:
             X: Input to the DNN.
             y: Ground truth.
-            x_list: Vector in list format (same shape as trainable model parameters).
+            M_list: Matrix to be multiplied with in list format.
+                Tensors have same shape as trainable model parameters, and an
+            additional leading axis for the matrix columns.
 
         Returns:
-            Result of Hessian-multiplication in list format.
+            Result of activation Hessian multiplication in list format. Has the same
+            shape as ``M_list``, i.e. each tensor in the list has the shape of a
+            parameter and a leading dimension of matrix columns.
         """
         activation_storage = []
         with store_activation(self._model_func, *self._activation, activation_storage):
             loss = self._loss_func(self._model_func(X), y)
         activation = activation_storage.pop()
 
-        return hessian_vector_product(loss, [activation], x_list)
+        # Re-cycle first backward pass of the HVP's double-backward
+        # between columns the Hessian is multiplied onto
+        grad_activation = grad(loss, activation, create_graph=True)
 
-    def _preprocess(self, x: ndarray) -> List[Tensor]:
-        """Reshape the incoming vector into the activation shape and convert to PyTorch.
+        # collect
+        result_list = [zeros_like(M) for M in M_list]
+
+        num_vectors = M_list[0].shape[0]
+        for n in range(num_vectors):
+            out_n_list = hessian_vector_product(
+                loss, [activation], [M[n] for M in M_list], grad_params=grad_activation
+            )
+            for result, out_n in zip(result_list, out_n_list):
+                result[n].add_(out_n)
+
+        return tuple(result_list)
+
+    def _preprocess(self, M: ndarray) -> List[Tensor]:
+        """Reshape the incoming matrix into the activation shape and convert to PyTorch.
 
         Args:
-            x: Vector in NumPy format onto which the linear operator is applied.
+            M: Matrix in NumPy format onto which the linear operator is applied.
 
         Returns:
-            Vector in PyTorch format. Has same shape as the activation.
+            Matrix in PyTorch format. Has same shape as the activation with an
+            additional leading axis for the matrix columns.
         """
-        return [from_numpy(x).to(self._device).reshape(self._activation_shape)]
+        num_vectors = M.shape[1]
+        return [
+            from_numpy(M.T)
+            .to(self._device)
+            .reshape(num_vectors, *self._activation_shape)
+        ]
 
 
 class store_activation:

--- a/curvlinops/experimental/activation_hessian.py
+++ b/curvlinops/experimental/activation_hessian.py
@@ -140,7 +140,7 @@ class ActivationHessianLinearOperator(_LinearOperator):
             y: Ground truth.
             M_list: Matrix to be multiplied with in list format.
                 Tensors have same shape as trainable model parameters, and an
-            additional leading axis for the matrix columns.
+                additional leading axis for the matrix columns.
 
         Returns:
             Result of activation Hessian multiplication in list format. Has the same

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from math import sqrt
 from typing import Callable, Iterable, List, Optional, Tuple, Union
 
+from einops import einsum
 from numpy import ndarray
 from torch import (
     Generator,
@@ -175,40 +176,45 @@ class FisherMCLinearOperator(_LinearOperator):
             num_data=num_data,
         )
 
-    def _matvec(self, x: ndarray) -> ndarray:
-        """Loop over all batches in the data and apply the matrix to vector x.
+    def _matmat(self, X: ndarray) -> ndarray:
+        """Multiply the MC-Fisher onto a matrix.
 
         Create and seed the random number generator.
 
         Args:
-            x: Vector for multiplication.
+            X: Matrix for multiplication.
 
         Returns:
-            Matrix-multiplication result ``mat @ x``.
+            Matrix-multiplication result ``mat @ X``.
         """
         if self._generator is None:
             self._generator = Generator(device=self._device)
         self._generator.manual_seed(self._seed)
 
-        return super()._matvec(x)
+        return super()._matmat(X)
 
-    def _matvec_batch(
-        self, X: Tensor, y: Tensor, x_list: List[Tensor]
+    def _matmat_batch(
+        self, X: Tensor, y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
-        """Apply the mini-batch MC-Fisher to a vector.
+        """Apply the mini-batch MC-Fisher to a matrix.
 
         Args:
             X: Input to the DNN.
             y: Ground truth.
-            x_list: Vector in list format (same shape as trainable model parameters).
+            M_list: Matrix to be multiplied with in list format.
+                Tensors have same shape as trainable model parameters, and an
+            additional leading axis for the matrix columns.
 
         Returns:
-            Result of MC-Fisher-multiplication in list format.
+            Result of MC-Fisher multiplication in list format. Has the same shape as
+            ``M_list``, i.e. each tensor in the list has the shape of a parameter and a
+            leading dimension of matrix columns.
         """
         N = X.shape[0]
         normalization = {"mean": N, "sum": 1.0}[self._loss_func.reduction]
 
-        result_list = [zeros_like(x) for x in x_list]
+        result_list = [zeros_like(M) for M in M_list]
+        num_vectors = M_list[0].shape[0]
 
         for n in range(N):
             X_n = X[n].unsqueeze(0)
@@ -224,14 +230,18 @@ class FisherMCLinearOperator(_LinearOperator):
                     grad_outputs=grad_output_sampled_n,
                     retain_graph=retain_graph,
                 )
+                # coefficients for each matrix-vector product
                 c = (
-                    sum((g * x).sum() for g, x in zip(grad_sampled_n, x_list))
+                    sum(
+                        einsum(g, M, "..., col ... -> col")
+                        for g, M in zip(grad_sampled_n, M_list)
+                    )
                     / self._mc_samples
                     / normalization
                 )
 
                 for idx, g in enumerate(grad_sampled_n):
-                    result_list[idx] += c * g
+                    result_list[idx].add_(einsum(c, g, "col, ... -> col ..."))
 
         return tuple(result_list)
 

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -203,7 +203,7 @@ class FisherMCLinearOperator(_LinearOperator):
             y: Ground truth.
             M_list: Matrix to be multiplied with in list format.
                 Tensors have same shape as trainable model parameters, and an
-            additional leading axis for the matrix columns.
+                additional leading axis for the matrix columns.
 
         Returns:
             Result of MC-Fisher multiplication in list format. Has the same shape as
@@ -214,7 +214,6 @@ class FisherMCLinearOperator(_LinearOperator):
         normalization = {"mean": N, "sum": 1.0}[self._loss_func.reduction]
 
         result_list = [zeros_like(M) for M in M_list]
-        num_vectors = M_list[0].shape[0]
 
         for n in range(N):
             X_n = X[n].unsqueeze(0)

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -176,22 +176,22 @@ class FisherMCLinearOperator(_LinearOperator):
             num_data=num_data,
         )
 
-    def _matmat(self, X: ndarray) -> ndarray:
+    def _matmat(self, M: ndarray) -> ndarray:
         """Multiply the MC-Fisher onto a matrix.
 
         Create and seed the random number generator.
 
         Args:
-            X: Matrix for multiplication.
+            M: Matrix for multiplication.
 
         Returns:
-            Matrix-multiplication result ``mat @ X``.
+            Matrix-multiplication result ``mat @ M``.
         """
         if self._generator is None:
             self._generator = Generator(device=self._device)
         self._generator.manual_seed(self._seed)
 
-        return super()._matmat(X)
+        return super()._matmat(M)
 
     def _matmat_batch(
         self, X: Tensor, y: Tensor, M_list: List[Tensor]

--- a/curvlinops/ggn.py
+++ b/curvlinops/ggn.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Tuple
 
 from backpack.hessianfree.ggnvp import ggn_vector_product_from_plist
-from torch import Tensor, stack, zeros_like
+from torch import Tensor, zeros_like
 
 from curvlinops._base import _LinearOperator
 
@@ -50,7 +50,7 @@ class GGNLinearOperator(_LinearOperator):
             y: Ground truth.
             M_list: Matrix to be multiplied with in list format.
                 Tensors have same shape as trainable model parameters, and an
-            additional leading axis for the matrix columns.
+                additional leading axis for the matrix columns.
 
         Returns:
             Result of GGN multiplication in list format. Has the same shape as

--- a/curvlinops/ggn.py
+++ b/curvlinops/ggn.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Tuple
 
 from backpack.hessianfree.ggnvp import ggn_vector_product_from_plist
-from torch import Tensor
+from torch import Tensor, stack, zeros_like
 
 from curvlinops._base import _LinearOperator
 
@@ -40,22 +40,38 @@ class GGNLinearOperator(_LinearOperator):
         \right)\,.
     """
 
-    def _matvec_batch(
-        self, X: Tensor, y: Tensor, x_list: List[Tensor]
+    def _matmat_batch(
+        self, X: Tensor, y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
-        """Apply the mini-batch GGN to a vector.
+        """Apply the mini-batch GGN to a matrix.
 
         Args:
             X: Input to the DNN.
             y: Ground truth.
-            x_list: Vector in list format (same shape as trainable model parameters).
+            M_list: Matrix to be multiplied with in list format.
+                Tensors have same shape as trainable model parameters, and an
+            additional leading axis for the matrix columns.
 
         Returns:
-            Result of GGN-multiplication in list format.
+            Result of GGN multiplication in list format. Has the same shape as
+            ``M_list``, i.e. each tensor in the list has the shape of a parameter and a
+            leading dimension of matrix columns.
         """
         output = self._model_func(X)
         loss = self._loss_func(output, y)
-        return ggn_vector_product_from_plist(loss, output, self._params, x_list)
+
+        # collect matrix-matrix products per parameter
+        result_list = [zeros_like(M) for M in M_list]
+
+        num_vecs = M_list[0].shape[0]
+        for n in range(num_vecs):
+            col_n_list = ggn_vector_product_from_plist(
+                loss, output, self._params, [M[n] for M in M_list]
+            )
+            for result, col_n in zip(result_list, col_n_list):
+                result[n].add_(col_n)
+
+        return tuple(result_list)
 
     def _adjoint(self) -> GGNLinearOperator:
         """Return the linear operator representing the adjoint.

--- a/curvlinops/gradient_moments.py
+++ b/curvlinops/gradient_moments.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
-from torch import Tensor, autograd, einsum, zeros_like
+from einops import einsum
+from torch import Tensor, autograd, zeros_like
 
 from curvlinops._base import _LinearOperator
 
@@ -41,43 +42,47 @@ class EFLinearOperator(_LinearOperator):
         inefficient for-loop.
     """
 
-    def _matvec_batch(
-        self, X: Tensor, y: Tensor, x_list: List[Tensor]
+    def _matmat_batch(
+        self, X: Tensor, y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
-        """Apply the mini-batch uncentered gradient covariance to a vector.
+        """Apply the mini-batch empirical Fisher to a matrix.
 
         Args:
             X: Input to the DNN.
             y: Ground truth.
-            x_list: Vector in list format (same shape as trainable model parameters).
+            M_list: Matrix to be multiplied with in list format.
+                Tensors have same shape as trainable model parameters, and an
+            additional leading axis for the matrix columns.
 
         Returns:
-            Result of uncentered gradient covariance-multiplication in list format.
-
-        Raises:
-            ValueError: If the loss function's reduction cannot be determined.
+            Result of EF multiplication in list format. Has the same shape as
+            ``M_list``, i.e. each tensor in the list has the shape of a parameter and a
+            leading dimension of matrix columns.
         """
-        result_list = [zeros_like(x) for x in x_list]
+        reduction = self._loss_func.reduction
+        if reduction == "mean":
+            normalization = 1.0 / X.shape[0]
+        elif reduction == "sum":
+            normalization = 1.0
+        else:
+            raise ValueError("Loss must have reduction 'mean' or 'sum'.")
+
+        result_list = [zeros_like(M) for M in M_list]
 
         for n in range(X.shape[0]):
             X_n, y_n = X[n].unsqueeze(0), y[n].unsqueeze(0)
             loss_n = self._loss_func(self._model_func(X_n), y_n)
             grad_n = autograd.grad(loss_n, self._params)
 
-            c = sum(einsum("...,...->", g, x) for g, x in zip(grad_n, x_list))
+            # coefficients per matrix-vector product
+            c = sum(einsum(g, M, "..., col ...-> col") for g, M in zip(grad_n, M_list))
 
             for idx, g in enumerate(grad_n):
-                result_list[idx] += c * g
+                result_list[idx].add_(
+                    einsum(c, g, "col, ... -> col ..."), alpha=normalization
+                )
 
-        reduction = self._loss_func.reduction
-        if reduction == "mean":
-            normalization = X.shape[0]
-        elif reduction == "sum":
-            normalization = 1.0
-        else:
-            raise ValueError("Loss must have reduction 'mean' or 'sum'.")
-
-        return tuple(r / normalization for r in result_list)
+        return tuple(result_list)
 
     def _adjoint(self) -> EFLinearOperator:
         """Return the linear operator representing the adjoint.

--- a/curvlinops/gradient_moments.py
+++ b/curvlinops/gradient_moments.py
@@ -52,20 +52,18 @@ class EFLinearOperator(_LinearOperator):
             y: Ground truth.
             M_list: Matrix to be multiplied with in list format.
                 Tensors have same shape as trainable model parameters, and an
-            additional leading axis for the matrix columns.
+                additional leading axis for the matrix columns.
 
         Returns:
             Result of EF multiplication in list format. Has the same shape as
             ``M_list``, i.e. each tensor in the list has the shape of a parameter and a
             leading dimension of matrix columns.
+
+        Raises:
         """
-        reduction = self._loss_func.reduction
-        if reduction == "mean":
-            normalization = 1.0 / X.shape[0]
-        elif reduction == "sum":
-            normalization = 1.0
-        else:
-            raise ValueError("Loss must have reduction 'mean' or 'sum'.")
+        normalization = {"mean": 1.0 / X.shape[0], "sum": 1.0}[
+            self._loss_func.reduction
+        ]
 
         result_list = [zeros_like(M) for M in M_list]
 

--- a/curvlinops/hessian.py
+++ b/curvlinops/hessian.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import List, Tuple
 
 from backpack.hessianfree.hvp import hessian_vector_product
-from torch import Tensor
+from torch import Tensor, stack, zeros_like
+from torch.autograd import grad
 
 from curvlinops._base import _LinearOperator
 
@@ -32,21 +33,39 @@ class HessianLinearOperator(_LinearOperator):
         \ell(f_{\mathbf{\theta}}(\mathbf{x}_n), \mathbf{y}_n)\,.
     """
 
-    def _matvec_batch(
-        self, X: Tensor, y: Tensor, x_list: List[Tensor]
+    def _matmat_batch(
+        self, X: Tensor, y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
-        """Apply the mini-batch Hessian to a vector.
+        """Apply the mini-batch Hessian to a matrix.
 
         Args:
             X: Input to the DNN.
             y: Ground truth.
-            x_list: Vector in list format (same shape as trainable model parameters).
+            M_list: Matrix to be multiplied with in list format.
+                Tensors have same shape as trainable model parameters, and an
+            additional leading axis for the matrix columns.
 
         Returns:
-            Result of Hessian-multiplication in list format.
+            Result of Hessian multiplication in list format. Has the same shape as
+            ``M_list``, i.e. each tensor in the list has the shape of a parameter and a
+            leading dimension of matrix columns.
         """
         loss = self._loss_func(self._model_func(X), y)
-        return hessian_vector_product(loss, self._params, x_list)
+
+        # Re-cycle first backward pass from the HVP's double-backward
+        grad_params = grad(loss, self._params, create_graph=True)
+
+        result_list = [zeros_like(M) for M in M_list]
+
+        num_vecs = M_list[0].shape[0]
+        for n in range(num_vecs):
+            col_n_list = hessian_vector_product(
+                loss, self._params, [M[n] for M in M_list], grad_params=grad_params
+            )
+            for result, col_n in zip(result_list, col_n_list):
+                result[n].add_(col_n)
+
+        return result_list
 
     def _adjoint(self) -> HessianLinearOperator:
         """Return the linear operator representing the adjoint.

--- a/curvlinops/hessian.py
+++ b/curvlinops/hessian.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Tuple
 
 from backpack.hessianfree.hvp import hessian_vector_product
-from torch import Tensor, stack, zeros_like
+from torch import Tensor, zeros_like
 from torch.autograd import grad
 
 from curvlinops._base import _LinearOperator
@@ -43,7 +43,7 @@ class HessianLinearOperator(_LinearOperator):
             y: Ground truth.
             M_list: Matrix to be multiplied with in list format.
                 Tensors have same shape as trainable model parameters, and an
-            additional leading axis for the matrix columns.
+                additional leading axis for the matrix columns.
 
         Returns:
             Result of Hessian multiplication in list format. Has the same shape as

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -22,9 +22,9 @@ from functools import partial
 from math import sqrt
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
-from einops import rearrange, reduce
+from einops import einsum, rearrange, reduce
 from numpy import ndarray
-from torch import Generator, Tensor, cat, einsum, randn, stack
+from torch import Generator, Tensor, cat, randn, stack
 from torch.nn import Conv2d, CrossEntropyLoss, Linear, Module, MSELoss, Parameter
 from torch.utils.hooks import RemovableHandle
 
@@ -247,21 +247,19 @@ class KFACLinearOperator(_LinearOperator):
             num_data=num_data,
         )
 
-    def _matvec(self, x: ndarray) -> ndarray:
-        """Loop over all batches in the data and apply the matrix to vector x.
-
-        Create and seed the random number generator.
+    def _matmat(self, M: ndarray) -> ndarray:
+        """Apply KFAC to a matrix (multiple vectors).
 
         Args:
-            x: Vector for multiplication.
+            M: Matrix for multiplication. Has shape ``[D, K]`` with some ``K``.
 
         Returns:
-            Matrix-multiplication result ``mat @ x``.
+            Matrix-multiplication result ``KFAC @ M``. Has shape ``[D, K]``.
         """
         if not self._input_covariances and not self._gradient_covariances:
             self._compute_kfac()
 
-        x_torch = super()._preprocess(x)
+        M_torch = super()._preprocess(M)
 
         for name in self.param_ids_to_hooked_modules.values():
             mod = self._model_func.get_submodule(name)
@@ -271,14 +269,15 @@ class KFACLinearOperator(_LinearOperator):
                 mod.weight, mod.bias
             ):
                 w_pos, b_pos = self.param_pos(mod.weight), self.param_pos(mod.bias)
-                x_w = rearrange(x_torch[w_pos], "c_out ... -> c_out (...)")
-                x_joint = cat([x_w, x_torch[b_pos].unsqueeze(-1)], dim=1)
+                # v denotes the free dimension for treating multiple vectors in parallel
+                M_w = rearrange(M_torch[w_pos], "v c_out ... -> v c_out (...)")
+                M_joint = cat([M_w, M_torch[b_pos].unsqueeze(-1)], dim=2)
                 aaT = self._input_covariances[name]
                 ggT = self._gradient_covariances[name]
-                x_joint = ggT @ x_joint @ aaT
+                M_joint = einsum(ggT, M_joint, aaT, "i j,v j k,k l -> v i l")
 
-                w_cols = x_w.shape[1]
-                x_torch[w_pos], x_torch[b_pos] = x_joint.split([w_cols, 1], dim=1)
+                w_cols = M_w.shape[2]
+                M_torch[w_pos], M_torch[b_pos] = M_joint.split([w_cols, 1], dim=2)
 
             # for weights we need to multiply from the right with aaT
             # for weights and biases we need to multiply from the left with ggT
@@ -289,12 +288,24 @@ class KFACLinearOperator(_LinearOperator):
                         pos = self.param_pos(p)
 
                         if p_name == "weight":
-                            x_w = rearrange(x_torch[pos], "c_out ... -> c_out (...)")
-                            x_torch[pos] = x_w @ self._input_covariances[name]
+                            M_w = rearrange(
+                                M_torch[pos], "v c_out ... -> v c_out (...)"
+                            )
+                            M_torch[pos] = einsum(
+                                M_w,
+                                self._input_covariances[name],
+                                "v c_out j,j k -> v c_out k",
+                            )
 
-                        x_torch[pos] = self._gradient_covariances[name] @ x_torch[pos]
+                        print(self._gradient_covariances[name].shape)
+                        print(M_torch[pos].shape)
+                        M_torch[pos] = einsum(
+                            self._gradient_covariances[name],
+                            M_torch[pos],
+                            "j k,v k ... -> v j ...",
+                        )
 
-        return super()._postprocess(x_torch)
+        return self._postprocess(M_torch)
 
     def _adjoint(self) -> KFACLinearOperator:
         """Return the linear operator representing the adjoint.
@@ -509,7 +520,7 @@ class KFACLinearOperator(_LinearOperator):
             "batch+sequence": num_loss_terms**2
             / (self._N_data * self._mc_samples * sequence_length),
         }[self._loss_average]
-        covariance = einsum("bi,bj->ij", g, g).mul_(correction)
+        covariance = einsum(g, g, "b i,b j->i j").mul_(correction)
 
         name = self.get_module_name(module)
         if name not in self._gradient_covariances:
@@ -562,7 +573,7 @@ class KFACLinearOperator(_LinearOperator):
         ):
             x = cat([x, x.new_ones(x.shape[0], 1)], dim=1)
 
-        covariance = einsum("bi,bj->ij", x, x).div_(self._N_data * scale)
+        covariance = einsum(x, x, "b i,b j -> i j").div_(self._N_data * scale)
 
         name = self.get_module_name(module)
         if name not in self._input_covariances:

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -297,8 +297,6 @@ class KFACLinearOperator(_LinearOperator):
                                 "v c_out j,j k -> v c_out k",
                             )
 
-                        print(self._gradient_covariances[name].shape)
-                        print(M_torch[pos].shape)
                         M_torch[pos] = einsum(
                             self._gradient_covariances[name],
                             M_torch[pos],

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -137,10 +137,10 @@ def test_NeumannInverseLinearOperator_toy():
 @mark.parametrize(
     "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
 )
-def test_KFAC_inverse_damped_matvec(
+def test_KFAC_inverse_damped_matmat(
     case, cache: bool, exclude: str, separate_weight_and_bias: bool, delta: float = 1e-2
 ):
-    """Test matrix-vector multiplication by an inverse damped KFAC approximation."""
+    """Test matrix-matrix multiplication by an inverse damped KFAC approximation."""
     model_func, loss_func, params, data = case
 
     if exclude is not None:
@@ -172,8 +172,9 @@ def test_KFAC_inverse_damped_matvec(
         ggT.sub_(torch.eye(ggT.shape[0], device=ggT.device), alpha=delta)
     inv_KFAC = KFACInverseLinearOperator(KFAC, damping=(delta, delta), cache=cache)
 
-    x = random.rand(KFAC.shape[1])
-    report_nonclose(inv_KFAC @ x, inv_KFAC_naive @ x, rtol=5e-2)
+    num_vectors = 2
+    X = random.rand(KFAC.shape[1], num_vectors)
+    report_nonclose(inv_KFAC @ X, inv_KFAC_naive @ X, rtol=5e-2)
 
     assert inv_KFAC._cache == cache
     if cache:

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -15,7 +15,7 @@ from curvlinops.examples.functorch import functorch_ggn
 from curvlinops.examples.utils import report_nonclose
 
 
-def test_CG_inverse_damped_GGN_matvec(case, delta: float = 1e-2):
+def test_CG_inverse_damped_GGN_matvec(case, delta: float = 2e-2):
     """Test matrix-vector multiplication by the inverse damped GGN with CG."""
     model_func, loss_func, params, data = case
 


### PR DESCRIPTION
**Warning:** This is a big refactoring and it will require some iterations to reduce complexity.

Please complain about anything that is incomprehensible, and check for outdated/unclear docstrings.

Currently, all linear operators implement how to multiply with a single vector (`_matvec`).
Multiplying onto more than one vector is simply iterating over the vectors one by one (`_matmat`).
This adds a lot of sweeps through a data set which can be avoided by implementing matrix-matrix,
rather than matrix-vector multiplication.

This PR changes the base class implementation from `_matvec` to `_matmat`.