### PR TITLE
[ADD] Support block-diagonal Hessian approximation

### DIFF
--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -19,7 +19,14 @@ class _LinearOperator(LinearOperator):
     """Base class for linear operators of DNN matrices.
 
     Can be used with SciPy.
+
+    Attributes:
+        SUPPORTS_BLOCKS: Whether the linear operator supports multiplication with
+            a block-diagonal approximation rather than the full matrix.
+            Default: ``False``.
     """
+
+    SUPPORTS_BLOCKS: bool = False
 
     def __init__(
         self,
@@ -31,6 +38,7 @@ class _LinearOperator(LinearOperator):
         check_deterministic: bool = True,
         shape: Optional[Tuple[int, int]] = None,
         num_data: Optional[int] = None,
+        block_sizes: Optional[List[int]] = None,
     ):
         """Linear operator for DNN matrices.
 
@@ -59,9 +67,19 @@ class _LinearOperator(LinearOperator):
                 where ``D`` is the total number of parameters
             num_data: Number of data points. If ``None``, it is inferred from the data
                 at the cost of one traversal through the data loader.
+            block_sizes: This argument will be ignored if the linear operator does not
+                support blocks. List of integers indicating the number of
+                ``nn.Parameter``s that for a block. Entries must sum to ``len(params)``.
+                For instance ``[len(params)]`` considers the full matrix, while
+                ``[1, 1, ...]`` corresponds to a block diagonal approximation where
+                each parameter forms its own block.
 
         Raises:
             RuntimeError: If the check for deterministic behavior fails.
+            ValueError: If ``block_sizes`` is specified but the linear operator does not
+                support blocks.
+            ValueError: If the sum of blocks does not equal the number of parameters.
+            ValueError: If any block size is not positive.
         """
         if shape is None:
             dim = sum(p.numel() for p in params)
@@ -69,6 +87,17 @@ class _LinearOperator(LinearOperator):
         super().__init__(shape=shape, dtype=float32)
 
         self._params = params
+        if block_sizes is not None and not self.SUPPORTS_BLOCKS:
+            raise ValueError(
+                "Block sizes were specified but operator does not support blocking."
+            )
+        if block_sizes is not None:
+            if sum(block_sizes) != len(params):
+                raise ValueError("Sum of blocks must equal the number of parameters.")
+            if any(s <= 0 for s in block_sizes):
+                raise ValueError("Block sizes must be positive.")
+        self._block_sizes = [len(params)] if block_sizes is None else block_sizes
+
         self._model_func = model_func
         self._loss_func = loss_func
         self._data = data
@@ -228,7 +257,8 @@ class _LinearOperator(LinearOperator):
            Result of matrix-multiplication in list format.
 
         Raises:
-            NotImplementedError: Must be implemented by descendants.
+            NotImplementedError: Must be implemented by descendants which do not support
+                blocks.
         """
         raise NotImplementedError
 
@@ -334,21 +364,10 @@ class _LinearOperator(LinearOperator):
 
         Returns:
             Normalization factor
-
-        Raises:
-            ValueError: If loss function does not have a ``reduction`` attribute or
-                it is not set to ``'mean'`` or ``'sum'``.
         """
-        if not hasattr(self._loss_func, "reduction"):
-            raise ValueError("Loss must have a 'reduction' attribute.")
-
-        reduction = self._loss_func.reduction
-        if reduction == "sum":
-            return 1.0
-        elif reduction == "mean":
-            return X.shape[0] / self._N_data
-        else:
-            raise ValueError("Loss must have reduction 'mean' or 'sum'.")
+        return {"sum": 1.0, "mean": X.shape[0] / self._N_data}[
+            self._loss_func.reduction
+        ]
 
     @staticmethod
     def flatten_and_concatenate(tensors: List[Tensor]) -> Tensor:

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -257,8 +257,7 @@ class _LinearOperator(LinearOperator):
            Result of matrix-multiplication in list format.
 
         Raises:
-            NotImplementedError: Must be implemented by descendants which do not support
-                blocks.
+            NotImplementedError: Must be implemented by descendants.
         """
         raise NotImplementedError
 

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -69,7 +69,7 @@ class _LinearOperator(LinearOperator):
                 at the cost of one traversal through the data loader.
             block_sizes: This argument will be ignored if the linear operator does not
                 support blocks. List of integers indicating the number of
-                ``nn.Parameter``s that for a block. Entries must sum to ``len(params)``.
+                ``nn.Parameter``s forming a block. Entries must sum to ``len(params)``.
                 For instance ``[len(params)]`` considers the full matrix, while
                 ``[1, 1, ...]`` corresponds to a block diagonal approximation where
                 each parameter forms its own block.
@@ -87,11 +87,11 @@ class _LinearOperator(LinearOperator):
         super().__init__(shape=shape, dtype=float32)
 
         self._params = params
-        if block_sizes is not None and not self.SUPPORTS_BLOCKS:
-            raise ValueError(
-                "Block sizes were specified but operator does not support blocking."
-            )
         if block_sizes is not None:
+            if not self.SUPPORTS_BLOCKS:
+                raise ValueError(
+                    "Block sizes were specified but operator does not support blocking."
+                )
             if sum(block_sizes) != len(params):
                 raise ValueError("Sum of blocks must equal the number of parameters.")
             if any(s <= 0 for s in block_sizes):

--- a/curvlinops/hessian.py
+++ b/curvlinops/hessian.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple, Union
+from typing import List, Tuple
 
 from backpack.hessianfree.hvp import hessian_vector_product
 from torch import Tensor, zeros_like
 from torch.autograd import grad
-from torch.nn import Parameter
 
 from curvlinops._base import _LinearOperator
 from curvlinops.utils import split_list

--- a/curvlinops/hessian.py
+++ b/curvlinops/hessian.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from backpack.hessianfree.hvp import hessian_vector_product
 from torch import Tensor, zeros_like
 from torch.autograd import grad
+from torch.nn import Parameter
 
 from curvlinops._base import _LinearOperator
+from curvlinops.utils import split_list
 
 
 class HessianLinearOperator(_LinearOperator):
@@ -31,7 +33,13 @@ class HessianLinearOperator(_LinearOperator):
         c \sum_{n=1}^{N}
         \nabla_{\mathbf{\theta}}^2
         \ell(f_{\mathbf{\theta}}(\mathbf{x}_n), \mathbf{y}_n)\,.
+
+    Attributes:
+        SUPPORTS_BLOCKS: Whether the linear operator supports block operations.
+            Default is ``True``.
     """
+
+    SUPPORTS_BLOCKS: bool = True
 
     def _matmat_batch(
         self, X: Tensor, y: Tensor, M_list: List[Tensor]
@@ -55,17 +63,24 @@ class HessianLinearOperator(_LinearOperator):
         # Re-cycle first backward pass from the HVP's double-backward
         grad_params = grad(loss, self._params, create_graph=True)
 
-        result_list = [zeros_like(M) for M in M_list]
-
         num_vecs = M_list[0].shape[0]
-        for n in range(num_vecs):
-            col_n_list = hessian_vector_product(
-                loss, self._params, [M[n] for M in M_list], grad_params=grad_params
-            )
-            for result, col_n in zip(result_list, col_n_list):
-                result[n].add_(col_n)
+        result = [zeros_like(M) for M in M_list]
 
-        return result_list
+        # per-block HMP
+        for M_block, p_block, g_block, res_block in zip(
+            split_list(M_list, self._block_sizes),
+            split_list(self._params, self._block_sizes),
+            split_list(grad_params, self._block_sizes),
+            split_list(result, self._block_sizes),
+        ):
+            for n in range(num_vecs):
+                col_n = hessian_vector_product(
+                    loss, p_block, [M[n] for M in M_block], grad_params=g_block
+                )
+                for p, col in enumerate(col_n):
+                    res_block[p][n].add_(col)
+
+        return tuple(result)
 
     def _adjoint(self) -> HessianLinearOperator:
         """Return the linear operator representing the adjoint.

--- a/curvlinops/utils.py
+++ b/curvlinops/utils.py
@@ -1,0 +1,27 @@
+"""General utility functions."""
+
+from typing import List
+
+from numpy import cumsum
+
+
+def split_list(x: List, sizes: List[int]) -> List[List]:
+    """Split a list into multiple lists of specified size.
+
+    Args:
+        x: List to be split.
+        sizes: Sizes of the resulting lists.
+
+    Returns:
+        List of lists. Each sub-list has the size specified in ``sizes``.
+
+    Raises:
+        ValueError: If the sum of ``sizes`` does not match the input list's length.
+    """
+    if len(x) != sum(sizes):
+        raise ValueError(
+            f"List to be split has length {len(x)}, but requested sub-list with a total"
+            + f" of {sum(sizes)} entries."
+        )
+    boundaries = cumsum([0] + sizes)
+    return [x[boundaries[i] : boundaries[i + 1]] for i in range(len(sizes))]

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -1,10 +1,13 @@
 """Contains tests for ``curvlinops/hessian``."""
 
 from numpy import random
+from pytest import mark
+from torch import block_diag
 
 from curvlinops import HessianLinearOperator
 from curvlinops.examples.functorch import functorch_hessian
 from curvlinops.examples.utils import report_nonclose
+from curvlinops.utils import split_list
 
 
 def test_HessianLinearOperator_matvec(case, adjoint: bool):
@@ -20,6 +23,40 @@ def test_HessianLinearOperator_matvec(case, adjoint: bool):
 def test_HessianLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
     op = HessianLinearOperator(*case)
     op_functorch = functorch_hessian(*case).detach().cpu().numpy()
+    if adjoint:
+        op, op_functorch = op.adjoint(), op_functorch.conj().T
+
+    X = random.rand(op.shape[1], num_vecs)
+    report_nonclose(op @ X, op_functorch @ X, atol=1e-6, rtol=5e-4)
+
+
+BLOCKING_FNS = {
+    "per-parameter": lambda params: [1 for _ in range(len(params))],
+    "two-blocks": lambda params: (
+        [1] if len(params) == 1 else [len(params) // 2, len(params) - len(params) // 2]
+    ),
+}
+
+
+@mark.parametrize("blocking", BLOCKING_FNS.keys(), ids=BLOCKING_FNS.keys())
+def test_blocked_HessianLinearOperator_matmat(
+    case, adjoint: bool, blocking: str, num_vecs: int = 3
+):
+    """Test matrix-matrix multiplication with the block-diagonal Hessian."""
+    model, loss_func, params, data = case
+
+    # one parameter per block
+    block_sizes = BLOCKING_FNS[blocking](params)
+
+    op = HessianLinearOperator(model, loss_func, params, data, block_sizes=block_sizes)
+
+    # compute the blocks with functorch and build the block diagonal matrix
+    op_functorch = [
+        functorch_hessian(model, loss_func, params_block, data).detach()
+        for params_block in split_list(params, block_sizes)
+    ]
+    op_functorch = block_diag(*op_functorch).cpu().numpy()
+
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
 

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -42,7 +42,14 @@ BLOCKING_FNS = {
 def test_blocked_HessianLinearOperator_matmat(
     case, adjoint: bool, blocking: str, num_vecs: int = 2
 ):
-    """Test matrix-matrix multiplication with the block-diagonal Hessian."""
+    """Test matrix-matrix multiplication with the block-diagonal Hessian.
+
+    Args:
+        case: Tuple of model, loss function, parameters, and data.
+        adjoint: Whether to test the adjoint operator.
+        blocking: Blocking scheme.
+        num_vecs: Number of vectors to multiply with. Default is ``2``.
+    """
     model, loss_func, params, data = case
     block_sizes = BLOCKING_FNS[blocking](params)
 

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -40,12 +40,10 @@ BLOCKING_FNS = {
 
 @mark.parametrize("blocking", BLOCKING_FNS.keys(), ids=BLOCKING_FNS.keys())
 def test_blocked_HessianLinearOperator_matmat(
-    case, adjoint: bool, blocking: str, num_vecs: int = 3
+    case, adjoint: bool, blocking: str, num_vecs: int = 2
 ):
     """Test matrix-matrix multiplication with the block-diagonal Hessian."""
     model, loss_func, params, data = case
-
-    # one parameter per block
     block_sizes = BLOCKING_FNS[blocking](params)
 
     op = HessianLinearOperator(model, loss_func, params, data, block_sizes=block_sizes)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,14 @@
+"""Test general utility functions."""
+
+from pytest import raises
+
+from curvlinops.utils import split_list
+
+
+def test_split_list():
+    """Test list splitting utility function."""
+    assert split_list(["a", "b", "c", "d"], [1, 3]) == [["a"], ["b", "c", "d"]]
+    assert split_list(["a", "b", "c"], [3]) == [["a", "b", "c"]]
+
+    with raises(ValueError):
+        split_list(["a", "b", "c"], [1, 3])


### PR DESCRIPTION
Instead of multiplying with the Hessian w.r.t. the concatenation of all flattened params, this feature allows
breaking the parameters into smaller blocks and multiplying with the implied block-diagonal Hessian approximation.