### PR TITLE
[FIX] `Generator` device for sampling

### DIFF
--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -339,7 +339,7 @@ class KFACLinearOperator(_LinearOperator):
             )
 
         # loop over data set, computing the Kronecker factors
-        if self._generator is None:
+        if self._generator is None or self._generator.device != self._device:
             self._generator = Generator(device=self._device)
         self._generator.manual_seed(self._seed)
 


### PR DESCRIPTION
The device setting during sampling in `MCFisherLinearOperator` and `KFACLinearOperator` is currently broken. This is because `self._generator` will be created with `device="cpu"` to run `_check_deterministic()` and later it is only checked if `self._generator is None`. To fix this, we simply check `if self._generator.device != self._device` as well.

Moreover, the device of `std` was not set explicitly in one place.