### PR TITLE
Allow for matrix-matrix and matrix-vector products with `KFACLinearOperator` and `KFACInverseLinearOperator` without converting to numpy

### DIFF
--- a/curvlinops/inverse.py
+++ b/curvlinops/inverse.py
@@ -355,7 +355,7 @@ class KFACInverseLinearOperator(_InverseLinearOperator):
             parameter, i.e. ``[p1.shape, p2.shape, ...]``. If tensor, has shape ``[D]``.
 
         Raises:
-            ValueError: If the input tensor has the wrong shape.
+            ValueError: If the input tensor has the wrong data type.
         """
         if isinstance(v_torch, list):
             v_torch = [v_torch_i.unsqueeze(0) for v_torch_i in v_torch]

--- a/curvlinops/inverse.py
+++ b/curvlinops/inverse.py
@@ -331,7 +331,7 @@ class KFACInverseLinearOperator(_InverseLinearOperator):
                     )
 
         if return_tensor:
-            M_torch = cat([rearrange(M, "k ... -> (...) k") for M in M_torch], dim=0)
+            M_torch = cat([rearrange(M, "k ... -> (...) k") for M in M_torch])
 
         return M_torch
 
@@ -361,11 +361,12 @@ class KFACInverseLinearOperator(_InverseLinearOperator):
             v_torch = [v_torch_i.unsqueeze(0) for v_torch_i in v_torch]
             result = self.torch_matmat(v_torch)
             return [res.squeeze(0) for res in result]
+        elif isinstance(v_torch, Tensor):
+            return self.torch_matmat(v_torch.unsqueeze(-1)).squeeze(-1)
         else:
-            M = self.shape[0]
-            if v_torch.shape != (M,):
-                raise ValueError("The input vector has the wrong shape.")
-            return self.torch_matmat(v_torch.unsqueeze(1)).squeeze(1)
+            raise ValueError(
+                f"Invalid input type: {type(v_torch)}. Expected list of tensors or tensor."
+            )
 
     def _matmat(self, M: ndarray) -> ndarray:
         """Apply the inverse of KFAC to a matrix (multiple vectors).

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -379,7 +379,7 @@ class KFACLinearOperator(_LinearOperator):
                     )
 
         if return_tensor:
-            M_torch = cat([rearrange(M, "k ... -> (...) k") for M in M_torch], dim=0)
+            M_torch = cat([rearrange(M, "k ... -> (...) k") for M in M_torch])
 
         return M_torch
 
@@ -403,7 +403,7 @@ class KFACLinearOperator(_LinearOperator):
             parameter, i.e. ``[p1.shape, p2.shape, ...]``. If tensor, has shape ``[D]``.
 
         Raises:
-            ValueError: If the input tensor has the wrong shape.
+            ValueError: If the input tensor has the wrong data type.
         """
         if isinstance(v_torch, list):
             v_torch = [v_torch_i.unsqueeze(0) for v_torch_i in v_torch]

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -258,13 +258,6 @@ class KFACLinearOperator(_LinearOperator):
             an additional leading dimension of size ``K`` for the columns, i.e.
             ``[(K,) + p1.shape), (K,) + p2.shape, ...]``.
         """
-        if M.device != self._device:
-            warn(
-                f"Input matrix is on {M.device}, while linear operator is on "
-                + f"{self._device}. Converting to {self._device}."
-            )
-            M = M.to(self._device)
-
         num_vectors = M.shape[1]
         # split parameter blocks
         dims = [p.numel() for p in self._params]
@@ -272,7 +265,6 @@ class KFACLinearOperator(_LinearOperator):
         # column-index first + unflatten parameter dimension
         shapes = [(num_vectors,) + p.shape for p in self._params]
         result = [res.T.reshape(shape) for res, shape in zip(result, shapes)]
-
         return result
 
     def _check_input_type_and_preprocess(

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -368,7 +368,7 @@ class KFACLinearOperator(_LinearOperator):
             ValueError: If the input tensor has the wrong shape.
         """
         M = self.shape[0]
-        if v_torch.shape != (M,) and v_torch.shape != (M, 1):
+        if v_torch.shape not in [(M,), (M, 1)]:
             raise ValueError("dimension mismatch")
         return self.torch_matmat(v_torch.view(-1, 1), return_tensor).squeeze(1)
 

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -358,11 +358,11 @@ class KFACLinearOperator(_LinearOperator):
         device transfers when working with GPUs.
 
         Args:
-            v_torch: Vector for multiplication.
+            v_torch: Vector for multiplication. Has shape ``[D]``.
             return_tensor: Whether to return the result as a tensor or list of tensors.
 
         Returns:
-            Matrix-multiplication result ``KFAC @ M``. If tensor, has shape ``[D, K]``.
+            Matrix-multiplication result ``KFAC @ v``. If tensor, has shape ``[D]``.
 
         Raises:
             ValueError: If the input tensor has the wrong shape.

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 from functools import partial
 from math import sqrt
 from typing import Dict, Iterable, List, Optional, Tuple, Union
-from warnings import warn
 
 from einops import einsum, rearrange, reduce
 from numpy import ndarray

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -275,35 +275,74 @@ class KFACLinearOperator(_LinearOperator):
 
         return result
 
-    def torch_matmat(
-        self, M_torch: Union[Tensor, List[Tensor]], return_tensor: bool = True
-    ) -> Union[Tensor, List[Tensor]]:
-        """Apply KFAC to a matrix (multiple vectors) in PyTorch.
+    def _check_input_type_and_preprocess(
+        self, M_torch: Union[Tensor, List[Tensor]]
+    ) -> Tuple[bool, List[Tensor]]:
+        """Check input type and maybe preprocess to list format.
 
-        This allows for matrix-matrix products with the KFAC approximation in PyTorch
-        without converting tensors to numpy arrays, which avoids unnecessary
-        device transfers when working with GPUs.
+        Check whether the input is a tensor or a list of tensors. If it is a tensor,
+        preprocess to list format.
 
         Args:
-            M_torch: Matrix for multiplication. If tensor, has shape ``[D, K]`` with
-                some ``K``.
-            return_tensor: Whether to return the result as a tensor or list of tensors.
+            M_torch: Input to check.
 
         Returns:
-            Matrix-multiplication result ``KFAC @ M``. If tensor, has shape ``[D, K]``.
+            ``True`` if the input is a tensor, ``False`` if it is a list of tensors.
 
         Raises:
-            ValueError: If the input tensor has the wrong shape.
-            ValueError: If the input tensor's shape is incompatible with the KFAC
-                approximation's shape.
+            ValueError: If the input is a list of tensors that have a different number
+                of columns.
+            ValueError: If the input is a list of tensors that have incompatible shapes
+                with the parameters.
+            ValueError: If the input is a tensor and has the wrong shape.
+            ValueError: If the input is a tensor and its shape is incompatible with the
+                KFAC approximation's shape.
         """
-        if not isinstance(M_torch, list):
+        if isinstance(M_torch, list):
+            return_tensor = False
+            K = len(M_torch[0])
+            assert len(M_torch) == len(self._params)
+            for M, p in zip(M_torch, self._params):
+                if len(M) != K:
+                    raise ValueError(
+                        "All input tensors must have the same number of columns."
+                    )
+                if M.shape[1:] != p.shape:
+                    raise ValueError(
+                        "All input tensors must have (K,) + the same shape as the parameters."
+                    )
+        else:
+            return_tensor = True
             if M_torch.ndim != 2:
                 raise ValueError(f"expected 2-d tensor, not {M_torch.ndim}-d")
             if M_torch.shape[0] != self.shape[1]:
                 raise ValueError(f"dimension mismatch: {self.shape}, {M_torch.shape}")
             M_torch = self._torch_preprocess(M_torch)
+        return return_tensor, M_torch
 
+    def torch_matmat(
+        self, M_torch: Union[Tensor, List[Tensor]]
+    ) -> Union[Tensor, List[Tensor]]:
+        """Apply KFAC to a matrix (multiple vectors) in PyTorch.
+
+        This allows for matrix-matrix products with the KFAC approximation in PyTorch
+        without converting tensors to numpy arrays, which avoids unnecessary
+        device transfers when working with GPUs and flattening/concatenating.
+
+        Args:
+            M_torch: Matrix for multiplication. If list of tensors, each entry has the
+                same shape as a parameter with an additional leading dimension of size
+                ``K`` for the columns, i.e. ``[(K,) + p1.shape), (K,) + p2.shape, ...]``.
+                If tensor, has shape ``[D, K]`` with some ``K``.
+
+        Returns:
+            Matrix-multiplication result ``KFAC @ M``. Return type is the same as the
+            type of the input. If list of tensors, each entry has the same shape as a
+            parameter with an additional leading dimension of size ``K`` for the columns,
+            i.e. ``[(K,) + p1.shape), (K,) + p2.shape, ...]``. If tensor, has shape
+            ``[D, K]`` with some ``K``.
+        """
+        return_tensor, M_torch = self._check_input_type_and_preprocess(M_torch)
         if not self._input_covariances and not self._gradient_covariances:
             self._compute_kfac()
 
@@ -348,18 +387,15 @@ class KFACLinearOperator(_LinearOperator):
 
         return M_torch
 
-    def torch_matvec(
-        self, v_torch: Tensor, return_tensor: bool = True
-    ) -> Union[Tensor, List[Tensor]]:
+    def torch_matvec(self, v_torch: Tensor) -> Union[Tensor, List[Tensor]]:
         """Apply KFAC to a vector in PyTorch.
 
         This allows for matrix-vector products with the KFAC approximation in PyTorch
         without converting tensors to numpy arrays, which avoids unnecessary
-        device transfers when working with GPUs.
+        device transfers when working with GPUs and flattening/concatenating.
 
         Args:
             v_torch: Vector for multiplication. Has shape ``[D]``.
-            return_tensor: Whether to return the result as a tensor or list of tensors.
 
         Returns:
             Matrix-multiplication result ``KFAC @ v``. If tensor, has shape ``[D]``.
@@ -368,9 +404,9 @@ class KFACLinearOperator(_LinearOperator):
             ValueError: If the input tensor has the wrong shape.
         """
         M = self.shape[0]
-        if v_torch.shape not in [(M,), (M, 1)]:
-            raise ValueError("dimension mismatch")
-        return self.torch_matmat(v_torch.view(-1, 1), return_tensor).squeeze(1)
+        if v_torch.shape != (M,):
+            raise ValueError("The input vector has the wrong shape.")
+        return self.torch_matmat(v_torch.unsqueeze(1)).squeeze(1)
 
     def _matmat(self, M: ndarray) -> ndarray:
         """Apply KFAC to a matrix (multiple vectors).
@@ -382,7 +418,7 @@ class KFACLinearOperator(_LinearOperator):
             Matrix-multiplication result ``KFAC @ M``. Has shape ``[D, K]``.
         """
         M_torch = super()._preprocess(M)
-        M_torch = self.torch_matmat(M_torch, return_tensor=False)
+        M_torch = self.torch_matmat(M_torch)
         return self._postprocess(M_torch)
 
     def _adjoint(self) -> KFACLinearOperator:

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -213,7 +213,7 @@ def test_KFAC_inverse_damped_torch_matmat(case, delta: float = 1e-2):
     x_list = KFAC._torch_preprocess(X)
     inv_KFAC_x_list = inv_KFAC.torch_matmat(x_list)
     inv_KFAC_x_list = torch.cat(
-        [rearrange(M, "k ... -> (...) k") for M in inv_KFAC_x_list], dim=0
+        [rearrange(M, "k ... -> (...) k") for M in inv_KFAC_x_list]
     )
     report_nonclose(inv_KFAC_X, inv_KFAC_x_list.cpu().numpy())
 
@@ -255,9 +255,7 @@ def test_KFAC_inverse_damped_torch_matvec(case, delta: float = 1e-2):
     assert len(split_x) == len(KFAC._params)
     x_list = [res.reshape(p.shape) for res, p in zip(split_x, KFAC._params)]
     inv_kfac_x_list = inv_KFAC.torch_matvec(x_list)
-    inv_kfac_x_list = torch.cat(
-        [rearrange(M, "... -> (...)") for M in inv_kfac_x_list], dim=0
-    )
+    inv_kfac_x_list = torch.cat([rearrange(M, "... -> (...)") for M in inv_kfac_x_list])
     report_nonclose(inv_KFAC_x, inv_kfac_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -200,9 +200,12 @@ def test_KFAC_inverse_damped_torch_matmat(case, delta: float = 1e-2):
         loss_average=loss_average,
     )
     inv_KFAC = KFACInverseLinearOperator(KFAC, damping=(delta, delta))
+    device = KFAC._device
+    # KFAC.dtype is a numpy data type
+    dtype = next(KFAC._model_func.parameters()).dtype
 
     num_vectors = 2
-    X = torch.rand(KFAC.shape[1], num_vectors)
+    X = torch.rand(KFAC.shape[1], num_vectors, dtype=dtype, device=device)
     inv_KFAC_X = inv_KFAC.torch_matmat(X)
     assert inv_KFAC_X.dtype == X.dtype
     assert inv_KFAC_X.device == X.device
@@ -218,7 +221,8 @@ def test_KFAC_inverse_damped_torch_matmat(case, delta: float = 1e-2):
     report_nonclose(inv_KFAC_X, inv_KFAC_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix
-    inv_KFAC_mat = inv_KFAC.torch_matmat(torch.eye(inv_KFAC.shape[1]))
+    I = torch.eye(inv_KFAC.shape[1], dtype=dtype, device=device)
+    inv_KFAC_mat = inv_KFAC.torch_matmat(I)
     inv_KFAC_mat_x = inv_KFAC_mat @ X
     report_nonclose(inv_KFAC_X, inv_KFAC_mat_x.cpu().numpy(), rtol=5e-4)
 
@@ -240,8 +244,11 @@ def test_KFAC_inverse_damped_torch_matvec(case, delta: float = 1e-2):
         loss_average=loss_average,
     )
     inv_KFAC = KFACInverseLinearOperator(KFAC, damping=(delta, delta))
+    device = KFAC._device
+    # KFAC.dtype is a numpy data type
+    dtype = next(KFAC._model_func.parameters()).dtype
 
-    x = torch.rand(KFAC.shape[1])
+    x = torch.rand(KFAC.shape[1], dtype=dtype, device=device)
     inv_KFAC_x = inv_KFAC.torch_matvec(x)
     assert inv_KFAC_x.dtype == x.dtype
     assert inv_KFAC_x.device == x.device
@@ -259,7 +266,8 @@ def test_KFAC_inverse_damped_torch_matvec(case, delta: float = 1e-2):
     report_nonclose(inv_KFAC_x, inv_kfac_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix
-    inv_KFAC_mat = inv_KFAC.torch_matmat(torch.eye(inv_KFAC.shape[1]))
+    I = torch.eye(inv_KFAC.shape[1], dtype=dtype, device=device)
+    inv_KFAC_mat = inv_KFAC.torch_matmat(I)
     inv_KFAC_mat_x = inv_KFAC_mat @ x
     report_nonclose(inv_KFAC_x.cpu().numpy(), inv_KFAC_mat_x.cpu().numpy(), rtol=5e-5)
 

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -221,8 +221,8 @@ def test_KFAC_inverse_damped_torch_matmat(case, delta: float = 1e-2):
     report_nonclose(inv_KFAC_X, inv_KFAC_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix
-    I = torch.eye(inv_KFAC.shape[1], dtype=dtype, device=device)
-    inv_KFAC_mat = inv_KFAC.torch_matmat(I)
+    identity = torch.eye(inv_KFAC.shape[1], dtype=dtype, device=device)
+    inv_KFAC_mat = inv_KFAC.torch_matmat(identity)
     inv_KFAC_mat_x = inv_KFAC_mat @ X
     report_nonclose(inv_KFAC_X, inv_KFAC_mat_x.cpu().numpy(), rtol=5e-4)
 
@@ -266,8 +266,8 @@ def test_KFAC_inverse_damped_torch_matvec(case, delta: float = 1e-2):
     report_nonclose(inv_KFAC_x, inv_kfac_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix
-    I = torch.eye(inv_KFAC.shape[1], dtype=dtype, device=device)
-    inv_KFAC_mat = inv_KFAC.torch_matmat(I)
+    identity = torch.eye(inv_KFAC.shape[1], dtype=dtype, device=device)
+    inv_KFAC_mat = inv_KFAC.torch_matmat(identity)
     inv_KFAC_mat_x = inv_KFAC_mat @ x
     report_nonclose(inv_KFAC_x.cpu().numpy(), inv_KFAC_mat_x.cpu().numpy(), rtol=5e-5)
 

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -210,7 +210,7 @@ def test_KFAC_inverse_damped_torch_matmat(case, delta: float = 1e-2):
     # Test against multiplication with dense matrix
     inv_KFAC_mat = inv_KFAC.torch_matmat(torch.eye(inv_KFAC.shape[1]))
     inv_KFAC_mat_x = inv_KFAC_mat @ X
-    report_nonclose(inv_KFAC_X.cpu().numpy(), inv_KFAC_mat_x.cpu().numpy(), rtol=1e-4)
+    report_nonclose(inv_KFAC_X.cpu().numpy(), inv_KFAC_mat_x.cpu().numpy(), rtol=5e-4)
 
     # Test against _matmat
     report_nonclose(inv_KFAC @ X, inv_KFAC_X.cpu().numpy())

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -462,8 +462,8 @@ def test_torch_matmat(case):
     report_nonclose(kfac_x, kfac_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix
-    I = torch_eye(kfac.shape[1], dtype=dtype, device=device)
-    kfac_mat = kfac.torch_matmat(I)
+    identity = torch_eye(kfac.shape[1], dtype=dtype, device=device)
+    kfac_mat = kfac.torch_matmat(identity)
     kfac_mat_x = kfac_mat @ x
     report_nonclose(kfac_x, kfac_mat_x.cpu().numpy())
 
@@ -511,8 +511,8 @@ def test_torch_matvec(case):
     report_nonclose(kfac_x, kfac_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix
-    I = torch_eye(kfac.shape[1], dtype=dtype, device=device)
-    kfac_mat = kfac.torch_matmat(I)
+    identity = torch_eye(kfac.shape[1], dtype=dtype, device=device)
+    kfac_mat = kfac.torch_matmat(identity)
     kfac_mat_x = kfac_mat @ x
     report_nonclose(kfac_x, kfac_mat_x.cpu().numpy())
 

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -447,7 +447,8 @@ def test_torch_matmat(dev: device):
         fisher_type="empirical",
     )
 
-    x = rand(kfac.shape[1], 16, device=dev)
+    num_vectors = 16
+    x = rand(kfac.shape[1], num_vectors, device=dev)
     kfac_x = kfac.torch_matmat(x)
     assert x.device == kfac_x.device
     assert x.dtype == kfac_x.dtype


### PR DESCRIPTION
Addresses #71, but only for the `KFACLinearOperator` and `KFACInverseLinearOperator`.

`KFACLinearOperator`/`KFACInverseLinearOperator` is arguably the only linear operator here that is likely to be used for preconditioned-gradient methods for large scale neural networks. Therefore, adding `torch_matmat` and `torch_matvec` methods seem like a simple solution to avoid unnecessary device transfers, which are a bottleneck for this use case. However, this doesn't address the issue in general.