### PR TITLE
Add `fisher_type="forward-only"` (FOOF method) option to `KFACLinearOperator`

### DIFF
--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -155,7 +155,8 @@ class KFACLinearOperator(_LinearOperator):
                 used which corresponds to the uncentered gradient covariance, or
                 the empirical Fisher. If ``'forward-only'``, the gradient covariances
                 will be identity matrices, see the FOOF method in
-                `Benzing, 2022 <https://arxiv.org/abs/2201.12250>`_.
+                `Benzing, 2022 <https://arxiv.org/abs/2201.12250>`_ or ISAAC in
+                `Petersen et al., 2023 <https://arxiv.org/abs/2305.00604>`_.
                 Defaults to ``'mc'``.
             mc_samples: The number of Monte-Carlo samples to use per data point.
                 Has to be set to ``1`` when ``fisher_type != 'mc'``.

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -566,7 +566,7 @@ class KFACLinearOperator(_LinearOperator):
             # We choose to set the gradient covariance to the identity explicitly for
             # the sake of simplicity, such that the rest of the code here and for
             # `KFACInverseLinearOperator` does not have to be adapted. This could be
-            # decrease to improve the memory costs.
+            # adopted to decrease the memory costs.
             for mod_name, param_pos in self._mapping.items():
                 param = self._params[next(iter(param_pos.values()))]
                 self._gradient_covariances[mod_name] = eye(

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -566,7 +566,7 @@ class KFACLinearOperator(_LinearOperator):
             # We choose to set the gradient covariance to the identity explicitly for
             # the sake of simplicity, such that the rest of the code here and for
             # `KFACInverseLinearOperator` does not have to be adapted. This could be
-            # adopted to decrease the memory costs.
+            # changed to decrease the memory costs.
             for mod_name, param_pos in self._mapping.items():
                 param = self._params[next(iter(param_pos.values()))]
                 self._gradient_covariances[mod_name] = eye(

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -569,6 +569,10 @@ class KFACLinearOperator(_LinearOperator):
             # `KFACInverseLinearOperator` does not have to be adapted. This could be
             # changed to decrease the memory costs.
             for mod_name, param_pos in self._mapping.items():
+                # We iterate over _mapping to get the module names corresponding to the
+                # parameters. We only need the output dimension of the module, but
+                # don't know whether the parameter is a weight or bias; therefore, we
+                # just call `next(iter(param_pos.values()))` to get the first parameter.
                 param = self._params[next(iter(param_pos.values()))]
                 self._gradient_covariances[mod_name] = eye(
                     param.shape[0], dtype=param.dtype, device=self._device

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -24,7 +24,7 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from einops import einsum, rearrange, reduce
 from numpy import ndarray
-from torch import Generator, Tensor, cat, device, randn, stack
+from torch import Generator, Tensor, cat, device, eye, randn, stack
 from torch.nn import Conv2d, CrossEntropyLoss, Linear, Module, MSELoss, Parameter
 from torch.utils.hooks import RemovableHandle
 
@@ -90,6 +90,12 @@ class KFACLinearOperator(_LinearOperator):
         "batch",
         "batch+sequence",
     )
+    _SUPPORTED_FISHER_TYPE: Tuple[str, ...] = (
+        "type-2",
+        "mc",
+        "empirical",
+        "forward-only",
+    )
     _SUPPORTED_KFAC_APPROX: Tuple[str, ...] = ("expand", "reduce")
 
     def __init__(
@@ -147,7 +153,10 @@ class KFACLinearOperator(_LinearOperator):
                 by sampling ``mc_samples`` labels from the model's predictive
                 distribution. If ``'empirical'``, the empirical gradients are
                 used which corresponds to the uncentered gradient covariance, or
-                the empirical Fisher. Defaults to ``'mc'``.
+                the empirical Fisher. If ``'forward-only'``, the gradient covariances
+                will be identity matrices, see the FOOF method in
+                `Benzing, 2022 <https://arxiv.org/abs/2201.12250>`_.
+                Defaults to ``'mc'``.
             mc_samples: The number of Monte-Carlo samples to use per data point.
                 Has to be set to ``1`` when ``fisher_type != 'mc'``.
                 Defaults to ``1``.
@@ -199,6 +208,11 @@ class KFACLinearOperator(_LinearOperator):
             raise ValueError(
                 f"Loss function uses reduction='sum', but loss_average={loss_average}."
                 " Set loss_average to None if you want to use reduction='sum'."
+            )
+        if fisher_type not in self._SUPPORTED_FISHER_TYPE:
+            raise ValueError(
+                f"Invalid fisher_type: {fisher_type}. "
+                f"Supported: {self._SUPPORTED_FISHER_TYPE}."
             )
         if fisher_type != "mc" and mc_samples != 1:
             raise ValueError(
@@ -546,10 +560,23 @@ class KFACLinearOperator(_LinearOperator):
             loss = self._loss_func(output, y)
             loss.backward()
 
+        elif self._fisher_type == "forward-only":
+            # Since FOOF sets the gradient covariance Kronecker factors to the identity,
+            # we don't need to do a backward pass. See https://arxiv.org/abs/2201.12250.
+            # We choose to set the gradient covariance to the identity explicitly for
+            # the sake of simplicity, such that the rest of the code here and for
+            # `KFACInverseLinearOperator` does not have to be adapted. This could be
+            # decrease to improve the memory costs.
+            for mod_name, param_pos in self._mapping.items():
+                param = self._params[next(iter(param_pos.values()))]
+                self._gradient_covariances[mod_name] = eye(
+                    param.shape[0], dtype=param.dtype, device=self._device
+                )
+
         else:
             raise ValueError(
                 f"Invalid fisher_type: {self._fisher_type}. "
-                + "Supported: 'type-2', 'mc', 'empirical'."
+                + f"Supported: {self._SUPPORTED_FISHER_TYPE}."
             )
 
     def draw_label(self, output: Tensor) -> Tensor:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,7 @@ from test.kfac_cases import (
     KFAC_EXACT_ONE_DATUM_CASES,
     KFAC_WEIGHT_SHARING_EXACT_CASES,
     SINGLE_LAYER_CASES,
+    SINGLE_LAYER_WEIGHT_SHARING_CASES,
 )
 from typing import Callable, Dict, Iterable, List, Tuple
 
@@ -132,6 +133,25 @@ def single_layer_case(
     Iterable[Tuple[Tensor, Tensor]],
 ]:
     """Prepare a test case with a single-layer model for which FOOF is exact.
+
+    Yields:
+        A neural network, loss function, a list of parameters, and
+        a data set with a single datum.
+    """
+    case = request.param
+    yield initialize_case(case)
+
+
+@fixture(params=SINGLE_LAYER_WEIGHT_SHARING_CASES)
+def single_layer_weight_sharing_case(
+    request,
+) -> Tuple[
+    Module,
+    Module,
+    List[Tensor],
+    Iterable[Tuple[Tensor, Tensor]],
+]:
+    """Test case with a single-layer model with weight-sharing for which FOOF is exact.
 
     Yields:
         A neural network, loss function, a list of parameters, and

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ from test.kfac_cases import (
     KFAC_EXACT_CASES,
     KFAC_EXACT_ONE_DATUM_CASES,
     KFAC_WEIGHT_SHARING_EXACT_CASES,
+    SINGLE_LAYER_CASES,
 )
 from typing import Callable, Dict, Iterable, List, Tuple
 
@@ -112,6 +113,25 @@ def kfac_exact_one_datum_case(
     Iterable[Tuple[Tensor, Tensor]],
 ]:
     """Prepare a test case for which KFAC equals the GGN and one datum is used.
+
+    Yields:
+        A neural network, loss function, a list of parameters, and
+        a data set with a single datum.
+    """
+    case = request.param
+    yield initialize_case(case)
+
+
+@fixture(params=SINGLE_LAYER_CASES)
+def single_layer_case(
+    request,
+) -> Tuple[
+    Module,
+    Module,
+    List[Tensor],
+    Iterable[Tuple[Tensor, Tensor]],
+]:
+    """Prepare a test case with a single-layer model for which FOOF is exact.
 
     Yields:
         A neural network, loss function, a list of parameters, and

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -166,3 +166,53 @@ for case in SINGLE_LAYER_CASES_NO_DEVICE_NO_LOSS_FUNC:
                 "loss_func": partial(MSELoss, reduction=reduction),
             }
             SINGLE_LAYER_CASES.append(case_with_device_and_loss_func)
+
+
+# Add test cases here, devices and loss function with different reductions will be
+# added automatically below
+SINGLE_LAYER_WEIGHT_SHARING_CASES_NO_DEVICE_NO_LOSS_FUNC = [
+    ###############################################################################
+    #                                  REGRESSION                                 #
+    ###############################################################################
+    # single linear layer with vector output and weight-sharing dimensions
+    {
+        "model_func": lambda: WeightShareModel(Linear(5, 3)),
+        "data": lambda: {
+            "expand": [
+                (rand(7, 4, 8, 5), regression_targets((7, 4, 8, 3))),
+                (rand(7, 4, 8, 5), regression_targets((7, 4, 8, 3))),
+            ],
+            "reduce": [
+                (rand(8, 4, 8, 5), regression_targets((8, 3))),
+                (rand(8, 4, 8, 5), regression_targets((8, 3))),
+            ],
+        },
+        "seed": 0,
+    },
+    # Conv2d module with vector output (uses average pooling for reduce setting)
+    {
+        "model_func": lambda: Conv2dModel(),
+        "data": lambda: {
+            "expand": [
+                (rand(7, 3, 32, 32), regression_targets((7, 33, 33, 2))),
+                (rand(7, 3, 32, 32), regression_targets((7, 33, 33, 2))),
+            ],
+            "reduce": [
+                (rand(8, 3, 32, 32), regression_targets((8, 2))),
+                (rand(8, 3, 32, 32), regression_targets((8, 2))),
+            ],
+        },
+        "seed": 0,
+    },
+]
+
+SINGLE_LAYER_WEIGHT_SHARING_CASES = []
+for case in SINGLE_LAYER_WEIGHT_SHARING_CASES_NO_DEVICE_NO_LOSS_FUNC:
+    for device in get_available_devices():
+        for reduction in ["mean", "sum"]:
+            case_with_device_and_loss_func = {
+                **case,
+                "device": device,
+                "loss_func": partial(MSELoss, reduction=reduction),
+            }
+            SINGLE_LAYER_WEIGHT_SHARING_CASES.append(case_with_device_and_loss_func)

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -128,3 +128,41 @@ for case in KFAC_EXACT_ONE_DATUM_CASES_NO_DEVICE:
             "device": device,
         }
         KFAC_EXACT_ONE_DATUM_CASES.append(case_with_device)
+
+
+# Add test cases here, devices and loss function with different reductions will be
+# added automatically below
+SINGLE_LAYER_CASES_NO_DEVICE_NO_LOSS_FUNC = [
+    ###############################################################################
+    #                                  REGRESSION                                 #
+    ###############################################################################
+    # single-layer linear network with scalar output
+    {
+        "model_func": lambda: Linear(6, 1),
+        "data": lambda: [
+            (rand(5, 6), regression_targets((5, 1))),
+            (rand(5, 6), regression_targets((5, 1))),
+        ],
+        "seed": 0,
+    },
+    # single-layer linear network with vector output
+    {
+        "model_func": lambda: Linear(5, 3),
+        "data": lambda: [
+            (rand(7, 5), regression_targets((7, 3))),
+            (rand(7, 5), regression_targets((7, 3))),
+        ],
+        "seed": 0,
+    },
+]
+
+SINGLE_LAYER_CASES = []
+for case in SINGLE_LAYER_CASES_NO_DEVICE_NO_LOSS_FUNC:
+    for device in get_available_devices():
+        for reduction in ["mean", "sum"]:
+            case_with_device_and_loss_func = {
+                **case,
+                "device": device,
+                "loss_func": partial(MSELoss, reduction=reduction),
+            }
+            SINGLE_LAYER_CASES.append(case_with_device_and_loss_func)

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -131,6 +131,7 @@ def test_NeumannInverseLinearOperator_toy():
     report_nonclose(inv_neumann @ y, inv_ground_truth @ y, rtol=1e-3, atol=1e-5)
 
 
+@mark.parametrize("fisher_type", KFACLinearOperator._SUPPORTED_FISHER_TYPE)
 @mark.parametrize("cache", [True, False], ids=["cached", "uncached"])
 @mark.parametrize(
     "exclude", [None, "weight", "bias"], ids=["all", "no_weights", "no_biases"]
@@ -139,7 +140,12 @@ def test_NeumannInverseLinearOperator_toy():
     "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
 )
 def test_KFAC_inverse_damped_matmat(
-    case, cache: bool, exclude: str, separate_weight_and_bias: bool, delta: float = 1e-2
+    case,
+    fisher_type: str,
+    cache: bool,
+    exclude: str,
+    separate_weight_and_bias: bool,
+    delta: float = 1e-2,
 ):
     """Test matrix-matrix multiplication by an inverse damped KFAC approximation."""
     model_func, loss_func, params, data = case
@@ -156,6 +162,7 @@ def test_KFAC_inverse_damped_matmat(
         data,
         loss_average=loss_average,
         separate_weight_and_bias=separate_weight_and_bias,
+        fisher_type=fisher_type,
     )
 
     # add damping manually

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -985,7 +985,7 @@ def test_forward_only_fisher_type_exact_weight_sharing_case(
             else X.shape[1:-1].numel()
         )
         scale *= sequence_length
-    report_nonclose(ggn, 2 * scale * foof_mat, rtol=5e-5)
+    report_nonclose(ggn, 2 * scale * foof_mat, rtol=1e-4)
 
     # Check that input covariances were not computed
     if exclude == "weight":

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -810,7 +810,7 @@ def test_forward_only_fisher_type_exact_case(
     exclude: str,
     separate_weight_and_bias: bool,
 ):
-    """Test KFAC with forward-only Fisher (FOOF) against exact GGN for one-layer model.
+    r"""Test KFAC with forward-only Fisher (FOOF) against exact GGN for one-layer model.
 
     Consider linear regression with square loss, L =  R * \sum_n^N || W x_n - y_n ||^2,
     where R is the reduction factor from the MSELoss. Per definition,

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -985,7 +985,7 @@ def test_forward_only_fisher_type_exact_weight_sharing_case(
             else X.shape[1:-1].numel()
         )
         scale *= sequence_length
-    report_nonclose(ggn, 2 * scale * foof_mat)
+    report_nonclose(ggn, 2 * scale * foof_mat, rtol=5e-5)
 
     # Check that input covariances were not computed
     if exclude == "weight":

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -969,9 +969,7 @@ def test_forward_only_fisher_type_exact_weight_sharing_case(
 
     # Check for equivalence
     num_data = sum(X.shape[0] for X, _ in data)
-    X: Tensor
-    y: Tensor
-    X, y = data[0]
+    X, y = next(iter(data))
     out_dim = y.shape[-1]
     # See the docstring for the explanation of the scale
     scale = num_data if loss_average is None else 1 / out_dim


### PR DESCRIPTION
Add a `fisher_type` to implement the preconditioner used for [FOOF](https://arxiv.org/abs/2201.12250). This represents an extreme value for this argument since we only do a forward pass, compute the input covariances, and set the gradient covariances to identity matrices.