### PR TITLE
[ADD] Support `BCEWithLogitsLoss` in Fisher-MC and KFAC

### DIFF
--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -244,7 +244,7 @@ class FisherMCLinearOperator(_LinearOperator):
             output: model prediction ``f`` for multiple data with batch axis as
                 0th dimension.
             num_samples: Number of samples to draw.
-            y: Ground truth.
+            y: Labels of the data on which output was produced.
 
         Returns:
             Samples of the gradient w.r.t. the model prediction.

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -286,7 +286,7 @@ class FisherMCLinearOperator(_LinearOperator):
             if not unique.issubset({0, 1}):
                 raise NotImplementedError(
                     "Only binary targets (0, 1) are currently supported with"
-                    + f"BCEWithLogitsLoss. Got {unique}."
+                    + f" BCEWithLogitsLoss. Got {unique}."
                 )
             prob = output.sigmoid()
             # repeat ``num_sample`` times along a new leading axis

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -568,8 +568,10 @@ class KFACLinearOperator(_LinearOperator):
                     isinstance(self._loss_func, (BCEWithLogitsLoss, MSELoss))
                     and self._loss_func.reduction == "mean"
                 ):
-                    # ``BCEWithLogitsLoss`` and ``MSELoss`` also average over non-batch dimensions.
-                    # We have to scale the loss to incorporate this scaling into the drawn sample.
+                    # ``BCEWithLogitsLoss`` and ``MSELoss`` also average over non-batch
+                    # dimensions. We have to scale the loss to incorporate this scaling
+                    # as we cannot generally achieve it by incorporating it into the
+                    # drawn sample.
                     C = output.shape[1:].numel()
                     loss *= sqrt(C)
 

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -572,7 +572,7 @@ class KFACLinearOperator(_LinearOperator):
                     # dimensions. We have to scale the loss to incorporate this scaling
                     # as we cannot generally achieve it by incorporating it into the
                     # drawn sample.
-                    C = output.shape[1:].numel()
+                    _, C = output.shape
                     loss *= sqrt(C)
 
                 loss.backward(retain_graph=mc != self._mc_samples - 1)

--- a/test/cases.py
+++ b/test/cases.py
@@ -1,10 +1,16 @@
 """Contains test cases for linear operators."""
 
-from test.utils import classification_targets, get_available_devices, regression_targets
+from test.utils import (
+    binary_classification_targets,
+    classification_targets,
+    get_available_devices,
+    regression_targets,
+)
 
 from torch import rand, rand_like
 from torch.nn import (
     BatchNorm1d,
+    BCEWithLogitsLoss,
     CrossEntropyLoss,
     Dropout,
     Linear,
@@ -22,6 +28,7 @@ CASES_NO_DEVICE = [
     ###############################################################################
     #                                CLASSIFICATION                               #
     ###############################################################################
+    # softmax cross-entropy loss
     {
         "model_func": lambda: Sequential(Linear(10, 5), ReLU(), Linear(5, 2)),
         "loss_func": lambda: CrossEntropyLoss(reduction="mean"),
@@ -38,6 +45,36 @@ CASES_NO_DEVICE = [
         "data": lambda: [
             (rand(3, 10), classification_targets((3,), 2)),
             (rand(4, 10), classification_targets((4,), 2)),
+        ],
+        "seed": 0,
+    },
+    # binary softmax cross-entropy loss, one output
+    {
+        "model_func": lambda: Sequential(Linear(10, 5), ReLU(), Linear(5, 1)),
+        "loss_func": lambda: BCEWithLogitsLoss(reduction="mean"),
+        "data": lambda: [
+            (rand(3, 10), binary_classification_targets((3, 1))),
+            (rand(4, 10), binary_classification_targets((4, 1))),
+        ],
+        "seed": 0,
+    },
+    # binary softmax cross-entropy loss, multiple outputs (tests the reduction factor)
+    {
+        "model_func": lambda: Sequential(Linear(10, 5), ReLU(), Linear(5, 2)),
+        "loss_func": lambda: BCEWithLogitsLoss(reduction="mean"),
+        "data": lambda: [
+            (rand(3, 10), binary_classification_targets((3, 2))),
+            (rand(4, 10), binary_classification_targets((4, 2))),
+        ],
+        "seed": 0,
+    },
+    # binary softmax cross-entropy loss, multiple outputs and sum reduction
+    {
+        "model_func": lambda: Sequential(Linear(10, 5), ReLU(), Linear(5, 2)),
+        "loss_func": lambda: BCEWithLogitsLoss(reduction="sum"),
+        "data": lambda: [
+            (rand(3, 10), binary_classification_targets((3, 2))),
+            (rand(4, 10), binary_classification_targets((4, 2))),
         ],
         "seed": 0,
     },

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -4,13 +4,14 @@ from functools import partial
 from test.utils import (
     Conv2dModel,
     WeightShareModel,
+    binary_classification_targets,
     classification_targets,
     get_available_devices,
     regression_targets,
 )
 
 from torch import rand
-from torch.nn import CrossEntropyLoss, Linear, MSELoss, Sequential
+from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, Linear, MSELoss, Sequential
 
 # Add test cases here, devices and loss function with different reductions will be
 # added automatically below
@@ -116,6 +117,19 @@ KFAC_EXACT_ONE_DATUM_CASES_NO_DEVICE = [
         "model_func": lambda: Sequential(Linear(5, 4), Linear(4, 3)),
         "loss_func": lambda: CrossEntropyLoss(reduction="sum"),
         "data": lambda: [(rand(1, 5), classification_targets((1,), 3))],
+        "seed": 0,
+    },
+    # deep linear network with vector output and BCEWithLogitsLoss (both reductions)
+    {
+        "model_func": lambda: Sequential(Linear(4, 3), Linear(3, 2)),
+        "loss_func": lambda: BCEWithLogitsLoss(reduction="mean"),
+        "data": lambda: [(rand(1, 4), binary_classification_targets((1, 2)))],
+        "seed": 0,
+    },
+    {
+        "model_func": lambda: Sequential(Linear(4, 3), Linear(3, 2)),
+        "loss_func": lambda: BCEWithLogitsLoss(reduction="sum"),
+        "data": lambda: [(rand(1, 4), binary_classification_targets((1, 2)))],
         "seed": 0,
     },
 ]

--- a/test/test_gradient_moments.py
+++ b/test/test_gradient_moments.py
@@ -14,7 +14,7 @@ def test_EFLinearOperator_matvec(case, adjoint: bool):
         op, op_functorch = op.adjoint(), op_functorch.conj().T
 
     x = random.rand(op.shape[1]).astype(op.dtype)
-    report_nonclose(op @ x, op_functorch @ x)
+    report_nonclose(op @ x, op_functorch @ x, atol=1e-7)
 
 
 def test_EFLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -17,7 +17,7 @@ def test_HessianLinearOperator_matvec(case, adjoint: bool):
         op, op_functorch = op.adjoint(), op_functorch.conj().T
 
     x = random.rand(op.shape[1])
-    report_nonclose(op @ x, op_functorch @ x)
+    report_nonclose(op @ x, op_functorch @ x, atol=1e-7)
 
 
 def test_HessianLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -20,6 +20,7 @@ from torch import Tensor, cat, cuda, device
 from torch import eye as torch_eye
 from torch import isinf, isnan, manual_seed, rand, randperm
 from torch.nn import (
+    BCEWithLogitsLoss,
     CrossEntropyLoss,
     Flatten,
     Linear,
@@ -215,7 +216,10 @@ def test_kfac_mc(
 
 def test_kfac_one_datum(
     kfac_exact_one_datum_case: Tuple[
-        Module, CrossEntropyLoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
+        Module,
+        Union[BCEWithLogitsLoss, CrossEntropyLoss],
+        List[Parameter],
+        Iterable[Tuple[Tensor, Tensor]],
     ]
 ):
     model, loss_func, params, data = kfac_exact_one_datum_case
@@ -232,7 +236,10 @@ def test_kfac_one_datum(
 
 def test_kfac_mc_one_datum(
     kfac_exact_one_datum_case: Tuple[
-        Module, CrossEntropyLoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
+        Module,
+        Union[BCEWithLogitsLoss, CrossEntropyLoss],
+        List[Parameter],
+        Iterable[Tuple[Tensor, Tensor]],
     ]
 ):
     model, loss_func, params, data = kfac_exact_one_datum_case
@@ -240,7 +247,7 @@ def test_kfac_mc_one_datum(
 
     ggn = ggn_block_diagonal(model, loss_func, params, data)
     kfac = KFACLinearOperator(
-        model, loss_func, params, data, mc_samples=10_000, loss_average=loss_average
+        model, loss_func, params, data, mc_samples=11_000, loss_average=loss_average
     )
     kfac_mat = kfac @ eye(kfac.shape[1])
 
@@ -252,7 +259,10 @@ def test_kfac_mc_one_datum(
 
 def test_kfac_ef_one_datum(
     kfac_exact_one_datum_case: Tuple[
-        Module, CrossEntropyLoss, List[Parameter], Iterable[Tuple[Tensor, Tensor]]
+        Module,
+        Union[BCEWithLogitsLoss, CrossEntropyLoss],
+        List[Parameter],
+        Iterable[Tuple[Tensor, Tensor]],
     ]
 ):
     model, loss_func, params, data = kfac_exact_one_datum_case

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -719,7 +719,7 @@ def test_logdet(case, exclude, separate_weight_and_bias, check_deterministic):
     assert not isinf(log_det) and not isnan(log_det)
     sign, logabsdet = slogdet(kfac @ eye(kfac.shape[1]))
     log_det_naive = sign * logabsdet
-    report_nonclose(log_det.cpu().numpy(), log_det_naive)
+    report_nonclose(log_det.cpu().numpy(), log_det_naive, rtol=2e-5)
 
     # Check that the logdet property is properly cached and reset
     assert kfac._logdet == log_det

--- a/test/test_submatrix_on_curvatures.py
+++ b/test/test_submatrix_on_curvatures.py
@@ -84,7 +84,7 @@ def test_SubmatrixLinearOperator_on_curvatures_matvec(
     A_sub_x = A_sub @ x
 
     assert A_sub_x.shape == (len(row_idxs),)
-    report_nonclose(A_sub_x, A_sub_functorch @ x, atol=1e-7)
+    report_nonclose(A_sub_x, A_sub_functorch @ x, atol=2e-7)
 
 
 @mark.parametrize("operator_case", CURVATURE_CASES)

--- a/test/test_submatrix_on_curvatures.py
+++ b/test/test_submatrix_on_curvatures.py
@@ -84,7 +84,7 @@ def test_SubmatrixLinearOperator_on_curvatures_matvec(
     A_sub_x = A_sub @ x
 
     assert A_sub_x.shape == (len(row_idxs),)
-    report_nonclose(A_sub_x, A_sub_functorch @ x)
+    report_nonclose(A_sub_x, A_sub_functorch @ x, atol=1e-7)
 
 
 @mark.parametrize("operator_case", CURVATURE_CASES)

--- a/test/utils.py
+++ b/test/utils.py
@@ -39,6 +39,18 @@ def classification_targets(size: Tuple[int], num_classes: int) -> Tensor:
     return randint(size=size, low=0, high=num_classes)
 
 
+def binary_classification_targets(size: Tuple[int]) -> Tensor:
+    """Create random binary targets.
+
+    Args:
+        size: Size of the targets to create.
+
+    Returns:
+        Random targets (float).
+    """
+    return classification_targets(size, 2).float()
+
+
 def regression_targets(size: Tuple[int]) -> Tensor:
     """Create random targets for regression.
 


### PR DESCRIPTION
This makes `curvlinops` support binary classification. Resolves #90 