### PR TITLE
Support arbitrary `X` in `data`

### DIFF
--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -12,10 +12,8 @@ from torch import device as torch_device
 from torch import from_numpy, tensor, zeros_like
 from torch.autograd import grad
 from torch.nn import Module, Parameter
-from torch.utils.data import DataLoader
 from tqdm import tqdm
 from collections import UserDict
-import collections.abc as cols_abc
 
 
 class _LinearOperator(LinearOperator):

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -1,6 +1,6 @@
 """Contains functionality to analyze Hessian & GGN via matrix-free multiplication."""
 
-from typing import Callable, Iterable, List, Optional, Tuple, Union, Any
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 from warnings import warn
 
 from einops import rearrange
@@ -13,7 +13,6 @@ from torch import from_numpy, tensor, zeros_like
 from torch.autograd import grad
 from torch.nn import Module, Parameter
 from tqdm import tqdm
-from collections import UserDict
 from collections.abc import MutableMapping
 
 

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -81,7 +81,7 @@ class _LinearOperator(LinearOperator):
                 each parameter forms its own block.
             batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
                 needs to be specified. The intended behavior is to consume the first
-                entry of the iterates from ``data`` and returns their batch size.
+                entry of the iterates from ``data`` and return their batch size.
 
         Raises:
             RuntimeError: If the check for deterministic behavior fails.

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -353,7 +353,7 @@ class _LinearOperator(LinearOperator):
             # if `X` is a custom data format
             if isinstance(X, Tensor):
                 X = X.to(self._device)
-            y.to(self._device)
+            y = y.to(self._device)
             yield (X, y)
 
     def gradient_and_loss(self) -> Tuple[List[Tensor], Tensor]:

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -36,7 +36,7 @@ class _LinearOperator(LinearOperator):
         model_func: Callable[[Tensor], Tensor],
         loss_func: Union[Callable[[Tensor, Tensor], Tensor], None],
         params: List[Parameter],
-        data: Union[Iterable[Tuple[Tensor, Tensor]], UserDict, dict, DataLoader],
+        data: Union[Iterable[Tuple[Tensor, Tensor]], Iterable[Tuple[UserDict, Tensor]], Iterable[Tuple[dict, Tensor]]],
         progressbar: bool = False,
         check_deterministic: bool = True,
         shape: Optional[Tuple[int, int]] = None,

--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -1,5 +1,6 @@
 """Contains functionality to analyze Hessian & GGN via matrix-free multiplication."""
 
+from collections.abc import MutableMapping
 from typing import Callable, Iterable, List, Optional, Tuple, Union
 from warnings import warn
 
@@ -13,7 +14,6 @@ from torch import from_numpy, tensor, zeros_like
 from torch.autograd import grad
 from torch.nn import Module, Parameter
 from tqdm import tqdm
-from collections.abc import MutableMapping
 
 
 class _LinearOperator(LinearOperator):

--- a/curvlinops/examples/functorch.py
+++ b/curvlinops/examples/functorch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import MutableMapping
 from math import sqrt
-from typing import Dict, Iterable, List, Tuple, Union, Optional, Callable
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 from torch import Tensor, cat, einsum
 from torch.func import functional_call, grad, hessian, jacrev, jvp, vmap

--- a/curvlinops/examples/functorch.py
+++ b/curvlinops/examples/functorch.py
@@ -234,11 +234,7 @@ def functorch_empirical_fisher(
 
     params_argnum = 2
     batch_grad_fn = vmap(grad(loss_n, argnums=params_argnum))
-
-    if batch_size_fn is None:
-        N = X.shape[0]
-    else:
-        N = batch_size_fn(X)
+    N = X.shape[0] if batch_size_fn is None else batch_size_fn(X)
 
     params_replicated_dict = {
         name: p.unsqueeze(0).expand(N, *(p.dim() * [-1]))
@@ -315,11 +311,10 @@ def _concatenate_batches(
             not provided.
     """
     X, y = list(zip(*list(data)))
+    y = cat(y)
 
     if isinstance(X[0], MutableMapping) and input_key is None:
         raise ValueError("input_key must be provided for dict-like X!")
-
-    y = cat(y)
 
     if isinstance(X[0], Tensor):
         return cat(X), y

--- a/curvlinops/experimental/activation_hessian.py
+++ b/curvlinops/experimental/activation_hessian.py
@@ -109,6 +109,8 @@ class ActivationHessianLinearOperator(_LinearOperator):
         # Compute shape of activation and ensure there is only one batch
         data_iter = iter(data)
         X, _ = next(data_iter)
+        (dev,) = {p.device for p in model_func.parameters()}
+        X = X.to(dev)
         activation_storage = []
         with store_activation(model_func, *activation, activation_storage):
             model_func(X)

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -14,6 +14,8 @@ from torch.nn.functional import one_hot
 
 from curvlinops._base import _LinearOperator
 
+from collections import UserDict
+
 
 class FisherMCLinearOperator(_LinearOperator):
     r"""Monte-Carlo approximation of the Fisher as SciPy linear operator.
@@ -109,7 +111,7 @@ class FisherMCLinearOperator(_LinearOperator):
         model_func: Callable[[Tensor], Tensor],
         loss_func: Union[MSELoss, CrossEntropyLoss],
         params: List[Parameter],
-        data: Iterable[Tuple[Tensor, Tensor]],
+        data: Union[Iterable[Tuple[Tensor, Tensor]], Iterable[Tuple[UserDict, Tensor]], Iterable[Tuple[dict, Tensor]]],
         progressbar: bool = False,
         check_deterministic: bool = True,
         seed: int = 2147483647,

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from math import sqrt
 from typing import Callable, Iterable, List, Optional, Tuple, Union
 
@@ -13,8 +14,6 @@ from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss, Parameter
 from torch.nn.functional import one_hot
 
 from curvlinops._base import _LinearOperator
-
-from collections.abc import MutableMapping
 
 
 class FisherMCLinearOperator(_LinearOperator):

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -192,7 +192,7 @@ class FisherMCLinearOperator(_LinearOperator):
         return super()._matmat(M)
 
     def _matmat_batch(
-        self, X: Tensor, y: Tensor, M_list: List[Tensor]
+        self, X: Union[Tensor, UserDict, dict], y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
         """Apply the mini-batch MC-Fisher to a matrix.
 
@@ -217,7 +217,7 @@ class FisherMCLinearOperator(_LinearOperator):
         # gₙₘ = ∂ℓₙ(yₙₘ)/∂fₙ (detached) and M is the number of MC samples.
         # The GGN of L' linearized at fₙ is the MC Fisher.
         # We can thus multiply with it by computing the GGN-vector products of L'.
-        reduction_factor = {"mean": X.shape[0], "sum": 1.0}[self._loss_func.reduction]
+        reduction_factor = {"mean": self._batch_size_fn(X), "sum": 1.0}[self._loss_func.reduction]
         loss = (
             0.5
             / reduction_factor

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -14,7 +14,7 @@ from torch.nn.functional import one_hot
 
 from curvlinops._base import _LinearOperator
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 
 class FisherMCLinearOperator(_LinearOperator):

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -154,12 +154,11 @@ class FisherMCLinearOperator(_LinearOperator):
                 at the cost of one traversal through the data loader.
             batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
                 needs to be specified. The intended behavior is to consume the first
-                entry of the iterates from ``data`` and returns their batch size.
+                entry of the iterates from ``data`` and return their batch size.
 
         Raises:
             NotImplementedError: If the loss function differs from ``MSELoss`` or
                 ``CrossEntropyLoss``.
-            ValueError: If ``X`` is not a tensor and ``batch_size_fn`` is not specified.
         """
         if not isinstance(loss_func, self.supported_losses):
             raise NotImplementedError(

--- a/curvlinops/fisher.py
+++ b/curvlinops/fisher.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import sqrt
-from typing import Callable, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Iterable, List, Optional, Tuple, Union, Any
 
 from backpack.hessianfree.ggnvp import ggn_vector_product_from_plist
 from einops import einsum, rearrange
@@ -115,6 +115,7 @@ class FisherMCLinearOperator(_LinearOperator):
         seed: int = 2147483647,
         mc_samples: int = 1,
         num_data: Optional[int] = None,
+        batch_size_fn: Optional[Callable[[Any], int]] = None
     ):
         """Linear operator for the MC approximation of the Fisher.
 
@@ -146,6 +147,8 @@ class FisherMCLinearOperator(_LinearOperator):
             mc_samples: Number of samples to use. Default: ``1``.
             num_data: Number of data points. If ``None``, it is inferred from the data
                 at the cost of one traversal through the data loader.
+            batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
+                needs to be specified.
 
         Raises:
             NotImplementedError: If the loss function differs from ``MSELoss`` or
@@ -166,6 +169,7 @@ class FisherMCLinearOperator(_LinearOperator):
             progressbar=progressbar,
             check_deterministic=check_deterministic,
             num_data=num_data,
+            batch_size_fn=batch_size_fn
         )
 
     def _matmat(self, M: ndarray) -> ndarray:

--- a/curvlinops/ggn.py
+++ b/curvlinops/ggn.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from collections.abc import MutableMapping
+from typing import List, Tuple, Union
 
 from backpack.hessianfree.ggnvp import ggn_vector_product_from_plist
 from torch import Tensor, zeros_like
@@ -41,7 +42,7 @@ class GGNLinearOperator(_LinearOperator):
     """
 
     def _matmat_batch(
-        self, X: Tensor, y: Tensor, M_list: List[Tensor]
+        self, X: Union[Tensor, MutableMapping], y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
         """Apply the mini-batch GGN to a matrix.
 

--- a/curvlinops/gradient_moments.py
+++ b/curvlinops/gradient_moments.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from typing import List, Tuple, Union
 
 from backpack.hessianfree.ggnvp import ggn_vector_product_from_plist
@@ -10,8 +11,6 @@ from torch import Tensor, zeros_like
 from torch.autograd import grad
 
 from curvlinops._base import _LinearOperator
-
-from collections.abc import MutableMapping
 
 
 class EFLinearOperator(_LinearOperator):

--- a/curvlinops/gradient_moments.py
+++ b/curvlinops/gradient_moments.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from backpack.hessianfree.ggnvp import ggn_vector_product_from_plist
 from einops import einsum
@@ -11,7 +11,7 @@ from torch.autograd import grad
 
 from curvlinops._base import _LinearOperator
 
-from collections import UserDict
+from collections.abc import MutableMapping
 
 
 class EFLinearOperator(_LinearOperator):
@@ -47,7 +47,7 @@ class EFLinearOperator(_LinearOperator):
     """
 
     def _matmat_batch(
-        self, X: Union[Tensor, UserDict, dict], y: Tensor, M_list: List[Tensor]
+        self, X: Union[Tensor, MutableMapping], y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
         """Apply the mini-batch empirical Fisher to a matrix.
 
@@ -64,7 +64,9 @@ class EFLinearOperator(_LinearOperator):
             leading dimension of matrix columns.
         """
         output = self._model_func(X)
-        reduction_factor = {"mean": self._batch_size_fn(X), "sum": 1.0}[self._loss_func.reduction]
+        reduction_factor = {"mean": self._batch_size_fn(X), "sum": 1.0}[
+            self._loss_func.reduction
+        ]
 
         # compute ∂ℓₙ/∂fₙ without reduction factor of L
         (grad_output,) = grad(self._loss_func(output, y), output)

--- a/curvlinops/gradient_moments.py
+++ b/curvlinops/gradient_moments.py
@@ -11,6 +11,8 @@ from torch.autograd import grad
 
 from curvlinops._base import _LinearOperator
 
+from collections import UserDict
+
 
 class EFLinearOperator(_LinearOperator):
     r"""Uncentered gradient covariance as SciPy linear operator.
@@ -45,7 +47,7 @@ class EFLinearOperator(_LinearOperator):
     """
 
     def _matmat_batch(
-        self, X: Tensor, y: Tensor, M_list: List[Tensor]
+        self, X: Union[Tensor, UserDict, dict], y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
         """Apply the mini-batch empirical Fisher to a matrix.
 
@@ -62,7 +64,7 @@ class EFLinearOperator(_LinearOperator):
             leading dimension of matrix columns.
         """
         output = self._model_func(X)
-        reduction_factor = {"mean": X.shape[0], "sum": 1.0}[self._loss_func.reduction]
+        reduction_factor = {"mean": self._batch_size_fn(X), "sum": 1.0}[self._loss_func.reduction]
 
         # compute ∂ℓₙ/∂fₙ without reduction factor of L
         (grad_output,) = grad(self._loss_func(output, y), output)

--- a/curvlinops/hessian.py
+++ b/curvlinops/hessian.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from collections.abc import MutableMapping
+from typing import List, Tuple, Union
 
 from backpack.hessianfree.hvp import hessian_vector_product
 from torch import Tensor, zeros_like
@@ -41,7 +42,7 @@ class HessianLinearOperator(_LinearOperator):
     SUPPORTS_BLOCKS: bool = True
 
     def _matmat_batch(
-        self, X: Tensor, y: Tensor, M_list: List[Tensor]
+        self, X: Union[Tensor, MutableMapping], y: Tensor, M_list: List[Tensor]
     ) -> Tuple[Tensor, ...]:
         """Apply the mini-batch Hessian to a matrix.
 

--- a/curvlinops/jacobian.py
+++ b/curvlinops/jacobian.py
@@ -28,6 +28,7 @@ class JacobianLinearOperator(_LinearOperator):
         progressbar: bool = False,
         check_deterministic: bool = True,
         num_data: Optional[int] = None,
+        batch_size_fn: Optional[Callable[[MutableMapping], int]] = None,
     ):
         r"""Linear operator for the Jacobian as SciPy linear operator.
 
@@ -56,11 +57,24 @@ class JacobianLinearOperator(_LinearOperator):
             check_deterministic: Check if model and data are deterministic.
             num_data: Number of data points. If ``None``, it is inferred from the data
                 at the cost of one traversal through the data loader.
+            batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
+                needs to be specified. The intended behavior is to consume the first
+                entry of the iterates from ``data`` and returns their batch size.
         """
-        num_data = sum(t.shape[0] for t, _ in data) if num_data is None else num_data
-        x = next(iter(data))[0].to(self._infer_device(params))
+        _batch_size_fn = (
+            (lambda X: X.shape[0]) if batch_size_fn is None else batch_size_fn
+        )
+        num_data = (
+            sum(_batch_size_fn(t) for t, _ in data) if num_data is None else num_data
+        )
+        x = next(iter(data))[0]
+
+        if isinstance(x, Tensor):
+            x = x.to(self._infer_device(params))
+
         num_outputs = model_func(x).shape[1:].numel()
         num_params = sum(p.numel() for p in params)
+
         super().__init__(
             model_func,
             None,
@@ -70,6 +84,7 @@ class JacobianLinearOperator(_LinearOperator):
             check_deterministic=check_deterministic,
             shape=(num_data * num_outputs, num_params),
             num_data=num_data,
+            batch_size_fn=batch_size_fn,
         )
 
     def _check_deterministic(self):
@@ -91,6 +106,12 @@ class JacobianLinearOperator(_LinearOperator):
 
         rtol, atol = 5e-5, 1e-6
 
+        def check_X_y(X1, X2, y1, y2):
+            if not allclose(X1, X2) or not allclose(y1, y2):
+                self.print_nonclose(X1, X2, rtol=rtol, atol=atol)
+                self.print_nonclose(y1, y2, rtol=rtol, atol=atol)
+                raise RuntimeError("Non-deterministic data loading detected.")
+
         with no_grad():
             for (X1, y1), (X2, y2) in zip(
                 self._loop_over_data(desc="_check_deterministic_data_pred"),
@@ -98,12 +119,15 @@ class JacobianLinearOperator(_LinearOperator):
             ):
                 pred1, y1 = self._model_func(X1).cpu().numpy(), y1.cpu().numpy()
                 pred2, y2 = self._model_func(X2).cpu().numpy(), y2.cpu().numpy()
-                X1, X2 = X1.cpu().numpy(), X2.cpu().numpy()
 
-                if not allclose(X1, X2) or not allclose(y1, y2):
-                    self.print_nonclose(X1, X2, rtol=rtol, atol=atol)
-                    self.print_nonclose(y1, y2, rtol=rtol, atol=atol)
-                    raise RuntimeError("Non-deterministic data loading detected.")
+                if isinstance(X1, Tensor) or isinstance(X2, Tensor):
+                    X1, X2 = X1.cpu().numpy(), X2.cpu().numpy()
+                    check_X_y(X1, X2, y1, y2)
+                else:  # X is a MutableMapping
+                    for (k1, v1), (k2, v2) in zip(X1.items(), X2.items()):
+                        if isinstance(v1, Tensor) or isinstance(v2, Tensor):
+                            X1, X2 = v1.cpu().numpy(), v2.cpu().numpy()
+                        check_X_y(X1, X2, y1, y2)
 
                 if not allclose(pred1, pred2):
                     self.print_nonclose(pred1, pred2, rtol=rtol, atol=atol)
@@ -151,6 +175,7 @@ class JacobianLinearOperator(_LinearOperator):
             self._data,
             progressbar=self._progressbar,
             check_deterministic=False,
+            batch_size_fn=self._batch_size_fn,
         )
 
 
@@ -168,6 +193,7 @@ class TransposedJacobianLinearOperator(_LinearOperator):
         progressbar: bool = False,
         check_deterministic: bool = True,
         num_data: Optional[int] = None,
+        batch_size_fn: Optional[Callable[[MutableMapping], int]] = None,
     ):
         r"""Linear operator for the transpose Jacobian as SciPy linear operator.
 
@@ -188,7 +214,7 @@ class TransposedJacobianLinearOperator(_LinearOperator):
 
         Note that the data must be supplied in deterministic order.
 
-        Args:
+            Args:
             model_func: Neural network function.
             params: Neural network parameters.
             data: Iterable of batched input-target pairs.
@@ -196,11 +222,24 @@ class TransposedJacobianLinearOperator(_LinearOperator):
             check_deterministic: Check if model and data are deterministic.
             num_data: Number of data points. If ``None``, it is inferred from the data
                 at the cost of one traversal through the data loader.
+            batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
+                needs to be specified. The intended behavior is to consume the first
+                entry of the iterates from ``data`` and returns their batch size.
         """
-        num_data = sum(t.shape[0] for t, _ in data) if num_data is None else num_data
-        x = next(iter(data))[0].to(self._infer_device(params))
+        _batch_size_fn = (
+            (lambda X: X.shape[0]) if batch_size_fn is None else batch_size_fn
+        )
+        num_data = (
+            sum(_batch_size_fn(t) for t, _ in data) if num_data is None else num_data
+        )
+        x = next(iter(data))[0]
+
+        if isinstance(x, Tensor):
+            x = x.to(self._infer_device(params))
+
         num_outputs = model_func(x).shape[1:].numel()
         num_params = sum(p.numel() for p in params)
+
         super().__init__(
             model_func,
             None,
@@ -210,6 +249,7 @@ class TransposedJacobianLinearOperator(_LinearOperator):
             check_deterministic=check_deterministic,
             shape=(num_params, num_data * num_outputs),
             num_data=num_data,
+            batch_size_fn=batch_size_fn,
         )
 
     def _check_deterministic(self):
@@ -238,12 +278,29 @@ class TransposedJacobianLinearOperator(_LinearOperator):
             ):
                 pred1, y1 = self._model_func(X1).cpu().numpy(), y1.cpu().numpy()
                 pred2, y2 = self._model_func(X2).cpu().numpy(), y2.cpu().numpy()
-                X1, X2 = X1.cpu().numpy(), X2.cpu().numpy()
 
-                if not allclose(X1, X2) or not allclose(y1, y2):
-                    self.print_nonclose(X1, X2, rtol=rtol, atol=atol)
-                    self.print_nonclose(y1, y2, rtol=rtol, atol=atol)
-                    raise RuntimeError("Non-deterministic data loading detected.")
+                def check_X_y(X1, X2, y1, y2):
+                    if not allclose(X1, X2) or not allclose(y1, y2):
+                        self.print_nonclose(X1, X2, rtol=rtol, atol=atol)
+                        self.print_nonclose(y1, y2, rtol=rtol, atol=atol)
+                        raise RuntimeError("Non-deterministic data loading detected.")
+
+                with no_grad():
+                    for (X1, y1), (X2, y2) in zip(
+                        self._loop_over_data(desc="_check_deterministic_data_pred"),
+                        self._loop_over_data(desc="_check_deterministic_data_pred2"),
+                    ):
+                        pred1, y1 = self._model_func(X1).cpu().numpy(), y1.cpu().numpy()
+                        pred2, y2 = self._model_func(X2).cpu().numpy(), y2.cpu().numpy()
+
+                        if isinstance(X1, Tensor) or isinstance(X2, Tensor):
+                            X1, X2 = X1.cpu().numpy(), X2.cpu().numpy()
+                            check_X_y(X1, X2, y1, y2)
+                        else:  # X is a MutableMapping
+                            for (k1, v1), (k2, v2) in zip(X1.items(), X2.items()):
+                                if isinstance(v1, Tensor) or isinstance(v2, Tensor):
+                                    X1, X2 = v1.cpu().numpy(), v2.cpu().numpy()
+                                check_X_y(X1, X2, y1, y2)
 
                 if not allclose(pred1, pred2):
                     self.print_nonclose(pred1, pred2, rtol=rtol, atol=atol)
@@ -295,4 +352,5 @@ class TransposedJacobianLinearOperator(_LinearOperator):
             self._data,
             progressbar=self._progressbar,
             check_deterministic=False,
+            batch_size_fn=self._batch_size_fn,
         )

--- a/curvlinops/jacobian.py
+++ b/curvlinops/jacobian.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, Iterable, List, Optional, Tuple
+from collections.abc import MutableMapping
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 from backpack.hessianfree.lop import transposed_jacobian_vector_product as vjp
 from backpack.hessianfree.rop import jacobian_vector_product as jvp
@@ -23,7 +24,7 @@ class JacobianLinearOperator(_LinearOperator):
         self,
         model_func: Callable[[Tensor], Tensor],
         params: List[Parameter],
-        data: Iterable[Tuple[Tensor, Tensor]],
+        data: Iterable[Tuple[Union[Tensor, MutableMapping], Tensor]],
         progressbar: bool = False,
         check_deterministic: bool = True,
         num_data: Optional[int] = None,
@@ -163,7 +164,7 @@ class TransposedJacobianLinearOperator(_LinearOperator):
         self,
         model_func: Callable[[Tensor], Tensor],
         params: List[Parameter],
-        data: Iterable[Tuple[Tensor, Tensor]],
+        data: Iterable[Tuple[Union[Tensor, MutableMapping], Tensor]],
         progressbar: bool = False,
         check_deterministic: bool = True,
         num_data: Optional[int] = None,

--- a/curvlinops/jacobian.py
+++ b/curvlinops/jacobian.py
@@ -59,7 +59,7 @@ class JacobianLinearOperator(_LinearOperator):
                 at the cost of one traversal through the data loader.
             batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
                 needs to be specified. The intended behavior is to consume the first
-                entry of the iterates from ``data`` and returns their batch size.
+                entry of the iterates from ``data`` and return their batch size.
         """
         _batch_size_fn = (
             (lambda X: X.shape[0]) if batch_size_fn is None else batch_size_fn
@@ -214,7 +214,7 @@ class TransposedJacobianLinearOperator(_LinearOperator):
 
         Note that the data must be supplied in deterministic order.
 
-            Args:
+        Args:
             model_func: Neural network function.
             params: Neural network parameters.
             data: Iterable of batched input-target pairs.
@@ -224,7 +224,7 @@ class TransposedJacobianLinearOperator(_LinearOperator):
                 at the cost of one traversal through the data loader.
             batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
                 needs to be specified. The intended behavior is to consume the first
-                entry of the iterates from ``data`` and returns their batch size.
+                entry of the iterates from ``data`` and return their batch size.
         """
         _batch_size_fn = (
             (lambda X: X.shape[0]) if batch_size_fn is None else batch_size_fn

--- a/curvlinops/jacobian.py
+++ b/curvlinops/jacobian.py
@@ -124,9 +124,12 @@ class JacobianLinearOperator(_LinearOperator):
                     X1, X2 = X1.cpu().numpy(), X2.cpu().numpy()
                     check_X_y(X1, X2, y1, y2)
                 else:  # X is a MutableMapping
-                    for (k1, v1), (k2, v2) in zip(X1.items(), X2.items()):
+                    for k in X1.keys():
+                        v1, v2 = X1[k], X2[k]
+
                         if isinstance(v1, Tensor) or isinstance(v2, Tensor):
                             X1, X2 = v1.cpu().numpy(), v2.cpu().numpy()
+
                         check_X_y(X1, X2, y1, y2)
 
                 if not allclose(pred1, pred2):
@@ -297,9 +300,12 @@ class TransposedJacobianLinearOperator(_LinearOperator):
                             X1, X2 = X1.cpu().numpy(), X2.cpu().numpy()
                             check_X_y(X1, X2, y1, y2)
                         else:  # X is a MutableMapping
-                            for (k1, v1), (k2, v2) in zip(X1.items(), X2.items()):
+                            for k in X1.keys():
+                                v1, v2 = X1[k], X2[k]
+
                                 if isinstance(v1, Tensor) or isinstance(v2, Tensor):
                                     X1, X2 = v1.cpu().numpy(), v2.cpu().numpy()
+
                                 check_X_y(X1, X2, y1, y2)
 
                 if not allclose(pred1, pred2):

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -43,6 +43,8 @@ from curvlinops.kfac_utils import (
     loss_hessian_matrix_sqrt,
 )
 
+from collections import UserDict
+
 
 class KFACLinearOperator(_LinearOperator):
     r"""Linear operator to multiply with the Fisher/GGN's KFAC approximation.
@@ -111,7 +113,7 @@ class KFACLinearOperator(_LinearOperator):
         model_func: Module,
         loss_func: MSELoss,
         params: List[Parameter],
-        data: Iterable[Tuple[Tensor, Tensor]],
+        data: Union[Iterable[Tuple[Tensor, Tensor]], Iterable[Tuple[UserDict, Tensor]], Iterable[Tuple[dict, Tensor]]],
         progressbar: bool = False,
         check_deterministic: bool = True,
         shape: Union[Tuple[int, int], None] = None,

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -193,7 +193,7 @@ class KFACLinearOperator(_LinearOperator):
                 at the cost of one traversal through the data loader.
             batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
                 needs to be specified. The intended behavior is to consume the first
-                entry of the iterates from ``data`` and returns their batch size.
+                entry of the iterates from ``data`` and return their batch size.
 
         Raises:
             ValueError: If the loss function is not supported.

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from functools import partial
 from math import sqrt
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union, Callable, Any
 
 from einops import einsum, rearrange, reduce
 from numpy import ndarray
@@ -122,6 +122,7 @@ class KFACLinearOperator(_LinearOperator):
         loss_average: Union[None, str] = "batch",
         separate_weight_and_bias: bool = True,
         num_data: Optional[int] = None,
+        batch_size_fn: Optional[Callable[[Any], int]] = None
     ):
         """Kronecker-factored approximate curvature (KFAC) proxy of the Fisher/GGN.
 
@@ -189,6 +190,8 @@ class KFACLinearOperator(_LinearOperator):
                 Defaults to ``True``.
             num_data: Number of data points. If ``None``, it is inferred from the data
                 at the cost of one traversal through the data loader.
+            batch_size_fn: If the ``X``'s in ``data`` are not ``torch.Tensor``, this
+                needs to be specified.
 
         Raises:
             ValueError: If the loss function is not supported.
@@ -257,6 +260,7 @@ class KFACLinearOperator(_LinearOperator):
             check_deterministic=check_deterministic,
             shape=shape,
             num_data=num_data,
+            batch_size_fn=batch_size_fn
         )
 
     def _reset_matrix_properties(self):

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -43,7 +43,7 @@ from curvlinops.kfac_utils import (
     loss_hessian_matrix_sqrt,
 )
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 
 class KFACLinearOperator(_LinearOperator):

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -18,9 +18,10 @@ and generalized to all linear layers with weight sharing in
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from functools import partial
 from math import sqrt
-from typing import Dict, Iterable, List, Optional, Tuple, Union, Callable
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 from einops import einsum, rearrange, reduce
 from numpy import ndarray
@@ -42,8 +43,6 @@ from curvlinops.kfac_utils import (
     extract_patches,
     loss_hessian_matrix_sqrt,
 )
-
-from collections.abc import MutableMapping
 
 
 class KFACLinearOperator(_LinearOperator):

--- a/docs/examples/basic_usage/example_huggingface.py
+++ b/docs/examples/basic_usage/example_huggingface.py
@@ -10,7 +10,7 @@ Remember to run :code:`pip install -U transformers datasets`
 from collections import UserDict
 from collections.abc import MutableMapping
 
-import numpy
+import numpy as np
 import torch
 import torch.utils.data as data_utils
 from datasets import Dataset
@@ -27,7 +27,7 @@ from curvlinops import GGNLinearOperator
 
 # make deterministic
 torch.manual_seed(0)
-numpy.random.seed(0)
+np.random.seed(0)
 
 # %%
 #
@@ -61,7 +61,7 @@ dataloader = data_utils.DataLoader(
 
 # %%
 #
-# Let's check the batch emitted by HF. We will see that it a :code:`UserDict`,
+# Let's check the batch emitted by HF. We will see that it is a :code:`UserDict`,
 # containing the input and label tensors. Note that :code:`UserDict` is
 # :code:`MutableMapping`, so it is compatible with :code:`curvlinops`.
 
@@ -160,7 +160,7 @@ ggn = GGNLinearOperator(
     batch_size_fn=batch_size_fn,  # Remember to specify this!
 )
 
-G = ggn @ torch.eye(ggn.shape[0])
+G = ggn @ np.eye(ggn.shape[0])
 
 print(f"GGN shape: {G.shape}")
 

--- a/docs/examples/basic_usage/example_huggingface.py
+++ b/docs/examples/basic_usage/example_huggingface.py
@@ -7,24 +7,23 @@ As always, let's first import the required functionality.
 Remember to run :code:`pip install -U transformers datasets`
 """
 
+from collections import UserDict
 from collections.abc import MutableMapping
+
 import numpy
 import torch
-from torch import nn
 import torch.utils.data as data_utils
-
-from curvlinops import GGNLinearOperator
-
+from datasets import Dataset
+from torch import nn
 from transformers import (
+    DataCollatorWithPadding,
     GPT2Config,
     GPT2ForSequenceClassification,
     GPT2Tokenizer,
-    DataCollatorWithPadding,
     PreTrainedTokenizer,
 )
-from datasets import Dataset
 
-from collections import UserDict
+from curvlinops import GGNLinearOperator
 
 # make deterministic
 torch.manual_seed(0)

--- a/docs/examples/basic_usage/example_huggingface.py
+++ b/docs/examples/basic_usage/example_huggingface.py
@@ -1,0 +1,144 @@
+r"""Usage with Huggingface LLMs
+===============================
+
+This example demonstrates how to work with Huggingface (HF) language models.
+
+As always, let's first import the required functionality. 
+Remember to run `pip install -U transformers datasets`
+"""
+
+import numpy
+import torch
+from torch import nn
+import torch.utils.data as data_utils
+
+from curvlinops import GGNLinearOperator
+
+from transformers import (
+    GPT2Config, GPT2ForSequenceClassification, GPT2Tokenizer, 
+    DataCollatorWithPadding
+)
+from datasets import Dataset
+
+from collections import UserDict
+
+# make deterministic
+torch.manual_seed(0)
+numpy.random.seed(0)
+
+# %%
+#
+# Data
+# ----
+#
+# We will use synthetic data for simplicty. But obviously this can 
+# be replace with any HF dataloader.
+
+tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+tokenizer.pad_token_id = tokenizer.eos_token_id
+
+data = [
+    {"text": "Today is hot, but I will manage!!!!", "label": 1},
+    {"text": "Tomorrow is cold", "label": 0},
+    {"text": "Carpe diem", "label": 1},
+    {"text": "Tempus fugit", "label": 1}
+]
+dataset = Dataset.from_list(data)
+
+def tokenize(row):
+    return tokenizer(row["text"])
+
+dataset = dataset.map(tokenize, remove_columns=["text"])
+dataset.set_format(type="torch", columns=["input_ids", "attention_mask", "label"])
+dataloader = data_utils.DataLoader(
+    dataset, batch_size=100,
+    collate_fn=DataCollatorWithPadding(tokenizer)
+)
+
+# %%
+#
+# Let's check the batch emitted by HF. We will see that it a :code:`UserDict`,
+# containing the input and label tensors.
+
+data = next(iter(dataloader))
+print(f"Is the data a UserDict? {isinstance(data, UserDict)}")
+for k, v in data.items():
+    print(k, v.shape)
+
+
+# %%
+#
+# Model
+# -----
+#
+# Curvlinops supports general :code:`UserDict` inputs. However, everything must
+# be handled inside inside the :code:`forward` function of the model. This gives
+# the users the most flexibility, without much overhead.
+#
+# Let's wrap the HF model to conform this requirement then.
+
+class MyGPT2(nn.Module):
+
+  def __init__(self, tokenizer):
+    super().__init__()
+    config = GPT2Config.from_pretrained('gpt2')
+    config.pad_token_id = tokenizer.pad_token_id
+    config.num_labels = 2
+    self.hf_model = GPT2ForSequenceClassification.from_pretrained('gpt2', config=config)
+
+    # For simplicity, only enable grad for the last layer
+    for p in self.hf_model.parameters():
+        p.requires_grad = False
+
+    for p in self.hf_model.score.parameters():
+        p.requires_grad = True
+
+  def forward(self, data: UserDict):
+    # Handle things like moving the input tensor to the correct device
+    # inside `forward`
+    device = next(self.parameters()).device
+    input_ids = data['input_ids'].to(device)
+    output_dict = self.hf_model(input_ids)
+    return output_dict.logits
+
+
+model = MyGPT2(tokenizer).to(torch.bfloat16)
+
+with torch.no_grad():
+    logits = model(data)
+    print(logits.shape)
+
+
+# %%
+#
+# Curvlinops
+# ----------
+#
+# We are now ready to compute the curvature of this HF model using Curvlinops.
+# For this, we need to define a function to tell Curvlinops how to get the
+# batch size of the :code:`UserDict` input batch. Everything else is unchanged
+# from the standard usage of Curvlinops!
+
+batch_size_fn = lambda x: x['input_ids'].shape[0]
+params = [p for p in model.parameters() if p.requires_grad]
+
+ggn = GGNLinearOperator(
+    model, nn.CrossEntropyLoss(), params,
+    [(data, data['labels'])],  # We still need to input a list of "(X, y)" pairs!
+    check_deterministic=False,
+    batch_size_fn=batch_size_fn  # Remember to specify this!
+)
+
+G = ggn @ torch.eye(ggn.shape[0])
+
+print(G.shape)
+
+
+# %%
+#
+# Conclusion
+# ----------
+#
+# This :code:`UserDict` specification is very flexible. This doesn't stop
+# at HF models. You can leverage this for any custom models!
+

--- a/docs/examples/basic_usage/example_huggingface.py
+++ b/docs/examples/basic_usage/example_huggingface.py
@@ -3,7 +3,7 @@ r"""Usage with Huggingface LLMs
 
 This example demonstrates how to work with Huggingface (HF) language models.
 
-As always, let's first import the required functionality. 
+As always, let's first import the required functionality.
 Remember to run `pip install -U transformers datasets`
 """
 
@@ -15,8 +15,10 @@ import torch.utils.data as data_utils
 from curvlinops import GGNLinearOperator
 
 from transformers import (
-    GPT2Config, GPT2ForSequenceClassification, GPT2Tokenizer, 
-    DataCollatorWithPadding
+    GPT2Config,
+    GPT2ForSequenceClassification,
+    GPT2Tokenizer,
+    DataCollatorWithPadding,
 )
 from datasets import Dataset
 
@@ -31,28 +33,29 @@ numpy.random.seed(0)
 # Data
 # ----
 #
-# We will use synthetic data for simplicty. But obviously this can 
+# We will use synthetic data for simplicty. But obviously this can
 # be replace with any HF dataloader.
 
-tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
 tokenizer.pad_token_id = tokenizer.eos_token_id
 
 data = [
     {"text": "Today is hot, but I will manage!!!!", "label": 1},
     {"text": "Tomorrow is cold", "label": 0},
     {"text": "Carpe diem", "label": 1},
-    {"text": "Tempus fugit", "label": 1}
+    {"text": "Tempus fugit", "label": 1},
 ]
 dataset = Dataset.from_list(data)
+
 
 def tokenize(row):
     return tokenizer(row["text"])
 
+
 dataset = dataset.map(tokenize, remove_columns=["text"])
 dataset.set_format(type="torch", columns=["input_ids", "attention_mask", "label"])
 dataloader = data_utils.DataLoader(
-    dataset, batch_size=100,
-    collate_fn=DataCollatorWithPadding(tokenizer)
+    dataset, batch_size=100, collate_fn=DataCollatorWithPadding(tokenizer)
 )
 
 # %%
@@ -77,29 +80,31 @@ for k, v in data.items():
 #
 # Let's wrap the HF model to conform this requirement then.
 
+
 class MyGPT2(nn.Module):
+    def __init__(self, tokenizer):
+        super().__init__()
+        config = GPT2Config.from_pretrained("gpt2")
+        config.pad_token_id = tokenizer.pad_token_id
+        config.num_labels = 2
+        self.hf_model = GPT2ForSequenceClassification.from_pretrained(
+            "gpt2", config=config
+        )
 
-  def __init__(self, tokenizer):
-    super().__init__()
-    config = GPT2Config.from_pretrained('gpt2')
-    config.pad_token_id = tokenizer.pad_token_id
-    config.num_labels = 2
-    self.hf_model = GPT2ForSequenceClassification.from_pretrained('gpt2', config=config)
+        # For simplicity, only enable grad for the last layer
+        for p in self.hf_model.parameters():
+            p.requires_grad = False
 
-    # For simplicity, only enable grad for the last layer
-    for p in self.hf_model.parameters():
-        p.requires_grad = False
+        for p in self.hf_model.score.parameters():
+            p.requires_grad = True
 
-    for p in self.hf_model.score.parameters():
-        p.requires_grad = True
-
-  def forward(self, data: UserDict):
-    # Handle things like moving the input tensor to the correct device
-    # inside `forward`
-    device = next(self.parameters()).device
-    input_ids = data['input_ids'].to(device)
-    output_dict = self.hf_model(input_ids)
-    return output_dict.logits
+    def forward(self, data: UserDict):
+        # Handle things like moving the input tensor to the correct device
+        # inside `forward`
+        device = next(self.parameters()).device
+        input_ids = data["input_ids"].to(device)
+        output_dict = self.hf_model(input_ids)
+        return output_dict.logits
 
 
 model = MyGPT2(tokenizer).to(torch.bfloat16)
@@ -119,14 +124,16 @@ with torch.no_grad():
 # batch size of the :code:`UserDict` input batch. Everything else is unchanged
 # from the standard usage of Curvlinops!
 
-batch_size_fn = lambda x: x['input_ids'].shape[0]
+batch_size_fn = lambda x: x["input_ids"].shape[0]
 params = [p for p in model.parameters() if p.requires_grad]
 
 ggn = GGNLinearOperator(
-    model, nn.CrossEntropyLoss(), params,
-    [(data, data['labels'])],  # We still need to input a list of "(X, y)" pairs!
+    model,
+    nn.CrossEntropyLoss(),
+    params,
+    [(data, data["labels"])],  # We still need to input a list of "(X, y)" pairs!
     check_deterministic=False,
-    batch_size_fn=batch_size_fn  # Remember to specify this!
+    batch_size_fn=batch_size_fn,  # Remember to specify this!
 )
 
 G = ggn @ torch.eye(ggn.shape[0])
@@ -141,4 +148,3 @@ print(G.shape)
 #
 # This :code:`UserDict` specification is very flexible. This doesn't stop
 # at HF models. You can leverage this for any custom models!
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,8 @@ lint =
 
 # Dependencies needed to build/view the documentation (semicolon/line-separated)
 docs =
+    transformers
+    datasets
     matplotlib
     sphinx-gallery
     sphinx-rtd-theme

--- a/test/cases.py
+++ b/test/cases.py
@@ -34,7 +34,8 @@ class ModelWithDictInput(Module):
         self.net = Sequential(Linear(10, 5), nonlin(), Linear(5, num_classes))
 
     def forward(self, data: MutableMapping):
-        x = data["x"]
+        device = next(self.parameters()).device
+        x = data["x"].to(device)
         return self.net(x)
 
 

--- a/test/cases.py
+++ b/test/cases.py
@@ -1,5 +1,6 @@
 """Contains test cases for linear operators."""
 
+from collections import UserDict
 from collections.abc import MutableMapping
 from test.utils import (
     binary_classification_targets,
@@ -10,19 +11,17 @@ from test.utils import (
 
 from torch import rand, rand_like
 from torch.nn import (
-    Module,
     BatchNorm1d,
     BCEWithLogitsLoss,
     CrossEntropyLoss,
     Dropout,
     Linear,
+    Module,
     MSELoss,
     ReLU,
     Sequential,
 )
 from torch.utils.data import DataLoader, TensorDataset
-
-from collections import UserDict
 
 DEVICES = get_available_devices()
 DEVICES_IDS = [f"dev={d}" for d in DEVICES]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -176,23 +176,3 @@ def single_layer_weight_sharing_case(
     """
     case = request.param
     yield initialize_case(case)
-
-
-# @fixture(params=DICT_CASES)
-# def dict_case(
-#     request,
-# ) -> Tuple[
-#     Module,
-#     Module,
-#     List[Tensor],
-#     Iterable[Tuple[Tensor, Tensor]],
-#     Optional[Callable[[MutableMapping], int]],
-# ]:
-#     """Test case with dict or UserDict x's.
-#
-#     Yields:
-#         A neural network, loss function, a list of parameters, and
-#         a data set with a single datum.
-#     """
-#     case = request.param
-#     yield initialize_case(case)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 """Contains pytest fixtures that are visible by other files."""
 
-from test.cases import ADJOINT_CASES, CASES, NON_DETERMINISTIC_CASES
+from test.cases import ADJOINT_CASES, CASES, DICT_CASES, NON_DETERMINISTIC_CASES
 from test.kfac_cases import (
     KFAC_EXACT_CASES,
     KFAC_EXACT_ONE_DATUM_CASES,
@@ -152,6 +152,25 @@ def single_layer_weight_sharing_case(
     Iterable[Tuple[Tensor, Tensor]],
 ]:
     """Test case with a single-layer model with weight-sharing for which FOOF is exact.
+
+    Yields:
+        A neural network, loss function, a list of parameters, and
+        a data set with a single datum.
+    """
+    case = request.param
+    yield initialize_case(case)
+
+
+@fixture(params=DICT_CASES)
+def dict_case(
+    request,
+) -> Tuple[
+    Module,
+    Module,
+    List[Tensor],
+    Iterable[Tuple[Tensor, Tensor]],
+]:
+    """Test case with dict or UserDict x's.
 
     Yields:
         A neural network, loss function, a list of parameters, and

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 """Contains pytest fixtures that are visible by other files."""
 
+import test.utils
 from collections.abc import MutableMapping
 from test.cases import ADJOINT_CASES, CASES, NON_DETERMINISTIC_CASES
 from test.kfac_cases import (
@@ -38,7 +39,7 @@ def initialize_case(
 
     try:
         if isinstance(next(iter(data))[0], MutableMapping):
-            batch_size_fn = lambda datum: datum["x"].shape[0]
+            batch_size_fn = test.utils.batch_size_fn
     except KeyError:  # The case of KFAC, where there are expand and reduce keys
         batch_size_fn = None
 

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -1,5 +1,6 @@
 """Contains test cases for the KFAC linear operator."""
 
+from collections import UserDict
 from functools import partial
 from test.utils import (
     Conv2dModel,
@@ -9,9 +10,17 @@ from test.utils import (
     get_available_devices,
     regression_targets,
 )
+from test.cases import ModelWithDictInput
 
 from torch import rand
-from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, Linear, MSELoss, Sequential
+from torch.nn import (
+    BCEWithLogitsLoss,
+    CrossEntropyLoss,
+    Linear,
+    MSELoss,
+    Sequential,
+    Identity,
+)
 
 # Add test cases here, devices and loss function with different reductions will be
 # added automatically below
@@ -34,6 +43,15 @@ KFAC_EXACT_CASES_NO_DEVICE_NO_LOSS_FUNC = [
         "data": lambda: [
             (rand(1, 5), regression_targets((1, 3))),
             (rand(7, 5), regression_targets((7, 3))),
+        ],
+        "seed": 0,
+    },
+    # deep linear network with dict-like input
+    {
+        "model_func": lambda: ModelWithDictInput(num_classes=3, nonlin=Identity),
+        "data": lambda: [
+            (UserDict({"x": rand(1, 10)}), regression_targets((1, 3))),
+            ({"x": rand(7, 10)}, regression_targets((7, 3))),
         ],
         "seed": 0,
     },

--- a/test/kfac_cases.py
+++ b/test/kfac_cases.py
@@ -2,6 +2,7 @@
 
 from collections import UserDict
 from functools import partial
+from test.cases import ModelWithDictInput
 from test.utils import (
     Conv2dModel,
     WeightShareModel,
@@ -10,16 +11,15 @@ from test.utils import (
     get_available_devices,
     regression_targets,
 )
-from test.cases import ModelWithDictInput
 
 from torch import rand
 from torch.nn import (
     BCEWithLogitsLoss,
     CrossEntropyLoss,
+    Identity,
     Linear,
     MSELoss,
     Sequential,
-    Identity,
 )
 
 # Add test cases here, devices and loss function with different reductions will be

--- a/test/test__base.py
+++ b/test/test__base.py
@@ -11,5 +11,10 @@ def test_check_deterministic(non_deterministic_case):
 
     with raises(RuntimeError):
         _LinearOperator(
-            model_func, loss_func, params, data, batch_size_fn, check_deterministic=True
+            model_func,
+            loss_func,
+            params,
+            data,
+            batch_size_fn=batch_size_fn,
+            check_deterministic=True,
         )

--- a/test/test__base.py
+++ b/test/test__base.py
@@ -7,7 +7,9 @@ from curvlinops._base import _LinearOperator
 
 def test_check_deterministic(non_deterministic_case):
     """Test that non-deterministic behavior is recognized."""
-    model_func, loss_func, params, data = non_deterministic_case
+    model_func, loss_func, params, data, batch_size_fn = non_deterministic_case
 
     with raises(RuntimeError):
-        _LinearOperator(model_func, loss_func, params, data, check_deterministic=True)
+        _LinearOperator(
+            model_func, loss_func, params, data, batch_size_fn, check_deterministic=True
+        )

--- a/test/test_fisher.py
+++ b/test/test_fisher.py
@@ -3,7 +3,7 @@
 from contextlib import suppress
 
 from numpy import random, zeros_like
-from pytest import mark
+from pytest import mark, raises
 
 from curvlinops import FisherMCLinearOperator
 from curvlinops.examples.functorch import functorch_ggn
@@ -78,3 +78,17 @@ def test_LinearOperator_matmat_expectation(
                 return
 
     report_nonclose(FX, GX, rtol=rtol, atol=atol)
+
+
+def test_FisherLinearOperator_dict(dict_case):
+    model_func, loss_func, params, data = dict_case
+    n_params = sum([p.numel() for p in params])
+
+    with raises(ValueError):
+        op = FisherMCLinearOperator(model_func, loss_func, params, data)
+
+    batch_size_fn = lambda data: data["x"].shape[0]
+    op = FisherMCLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    assert(op.shape == (n_params, n_params))

--- a/test/test_ggn.py
+++ b/test/test_ggn.py
@@ -1,5 +1,6 @@
 """Contains tests for ``curvlinops/ggn``."""
 
+from pytest import raises
 from numpy import random
 
 from curvlinops import GGNLinearOperator
@@ -33,3 +34,17 @@ def test_GGNLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
 
     X = random.rand(op.shape[1], num_vecs)
     report_nonclose(op @ X, op_functorch @ X)
+
+
+def test_GGNLinearOperator_dict(dict_case):
+    model_func, loss_func, params, data = dict_case
+    n_params = sum([p.numel() for p in params])
+
+    with raises(ValueError):
+        op = GGNLinearOperator(model_func, loss_func, params, data)
+
+    batch_size_fn = lambda data: data["x"].shape[0]
+    op = GGNLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    assert(op.shape == (n_params, n_params))

--- a/test/test_ggn.py
+++ b/test/test_ggn.py
@@ -1,8 +1,9 @@
 """Contains tests for ``curvlinops/ggn``."""
 
 from collections.abc import MutableMapping
-from pytest import raises
+
 from numpy import random
+from pytest import raises
 
 from curvlinops import GGNLinearOperator
 from curvlinops.examples.functorch import functorch_ggn

--- a/test/test_ggn.py
+++ b/test/test_ggn.py
@@ -22,7 +22,10 @@ def test_GGNLinearOperator_matvec(case, adjoint: bool):
         model_func, loss_func, params, data, batch_size_fn=batch_size_fn
     )
     op_functorch = (
-        functorch_ggn(model_func, loss_func, params, data, "x").detach().cpu().numpy()
+        functorch_ggn(model_func, loss_func, params, data, input_key="x")
+        .detach()
+        .cpu()
+        .numpy()
     )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
@@ -38,7 +41,10 @@ def test_GGNLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
         model_func, loss_func, params, data, batch_size_fn=batch_size_fn
     )
     op_functorch = (
-        functorch_ggn(model_func, loss_func, params, data, "x").detach().cpu().numpy()
+        functorch_ggn(model_func, loss_func, params, data, input_key="x")
+        .detach()
+        .cpu()
+        .numpy()
     )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T

--- a/test/test_gradient_moments.py
+++ b/test/test_gradient_moments.py
@@ -23,7 +23,12 @@ def test_EFLinearOperator_matvec(case, adjoint: bool):
     )
     op_functorch = (
         functorch_empirical_fisher(
-            model_func, loss_func, params, data, batch_size_fn, "x"
+            model_func,
+            loss_func,
+            params,
+            data,
+            batch_size_fn=batch_size_fn,
+            input_key="x",
         )
         .detach()
         .cpu()
@@ -44,7 +49,12 @@ def test_EFLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
     )
     op_functorch = (
         functorch_empirical_fisher(
-            model_func, loss_func, params, data, batch_size_fn, "x"
+            model_func,
+            loss_func,
+            params,
+            data,
+            batch_size_fn=batch_size_fn,
+            input_key="x",
         )
         .detach()
         .cpu()

--- a/test/test_gradient_moments.py
+++ b/test/test_gradient_moments.py
@@ -1,13 +1,13 @@
 """Contains tests for ``curvlinops/gradient_moments.py``."""
 
 from collections.abc import MutableMapping
+
 from numpy import random
+from pytest import raises
 
 from curvlinops import EFLinearOperator
 from curvlinops.examples.functorch import functorch_empirical_fisher
 from curvlinops.examples.utils import report_nonclose
-
-from pytest import raises
 
 
 def test_EFLinearOperator_matvec(case, adjoint: bool):

--- a/test/test_gradient_moments.py
+++ b/test/test_gradient_moments.py
@@ -1,5 +1,6 @@
 """Contains tests for ``curvlinops/gradient_moments.py``."""
 
+from collections.abc import MutableMapping
 from numpy import random
 
 from curvlinops import EFLinearOperator
@@ -10,8 +11,24 @@ from pytest import raises
 
 
 def test_EFLinearOperator_matvec(case, adjoint: bool):
-    op = EFLinearOperator(*case)
-    op_functorch = functorch_empirical_fisher(*case).detach().cpu().numpy()
+    model_func, loss_func, params, data, batch_size_fn = case
+
+    # Test when X is dict-like but batch_size_fn = None (default)
+    if isinstance(data[0][0], MutableMapping):
+        with raises(ValueError):
+            op = EFLinearOperator(model_func, loss_func, params, data)
+
+    op = EFLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    op_functorch = (
+        functorch_empirical_fisher(
+            model_func, loss_func, params, data, batch_size_fn, "x"
+        )
+        .detach()
+        .cpu()
+        .numpy()
+    )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
 
@@ -20,23 +37,21 @@ def test_EFLinearOperator_matvec(case, adjoint: bool):
 
 
 def test_EFLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
-    op = EFLinearOperator(*case)
-    op_functorch = functorch_empirical_fisher(*case).detach().cpu().numpy()
+    model_func, loss_func, params, data, batch_size_fn = case
+
+    op = EFLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    op_functorch = (
+        functorch_empirical_fisher(
+            model_func, loss_func, params, data, batch_size_fn, "x"
+        )
+        .detach()
+        .cpu()
+        .numpy()
+    )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
 
     X = random.rand(op.shape[1], num_vecs).astype(op.dtype)
     report_nonclose(op @ X, op_functorch @ X, atol=1e-7, rtol=1e-4)
-
-def test_EFLinearOperator_dict(dict_case):
-    model_func, loss_func, params, data = dict_case
-    n_params = sum([p.numel() for p in params])
-
-    with raises(ValueError):
-        op = EFLinearOperator(model_func, loss_func, params, data)
-
-    batch_size_fn = lambda data: data["x"].shape[0]
-    op = EFLinearOperator(
-        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
-    )
-    assert(op.shape == (n_params, n_params))

--- a/test/test_gradient_moments.py
+++ b/test/test_gradient_moments.py
@@ -6,6 +6,8 @@ from curvlinops import EFLinearOperator
 from curvlinops.examples.functorch import functorch_empirical_fisher
 from curvlinops.examples.utils import report_nonclose
 
+from pytest import raises
+
 
 def test_EFLinearOperator_matvec(case, adjoint: bool):
     op = EFLinearOperator(*case)
@@ -25,3 +27,16 @@ def test_EFLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
 
     X = random.rand(op.shape[1], num_vecs).astype(op.dtype)
     report_nonclose(op @ X, op_functorch @ X, atol=1e-7, rtol=1e-4)
+
+def test_EFLinearOperator_dict(dict_case):
+    model_func, loss_func, params, data = dict_case
+    n_params = sum([p.numel() for p in params])
+
+    with raises(ValueError):
+        op = EFLinearOperator(model_func, loss_func, params, data)
+
+    batch_size_fn = lambda data: data["x"].shape[0]
+    op = EFLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    assert(op.shape == (n_params, n_params))

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -1,7 +1,7 @@
 """Contains tests for ``curvlinops/hessian``."""
 
 from numpy import random
-from pytest import mark
+from pytest import mark, raises
 from torch import block_diag
 
 from curvlinops import HessianLinearOperator
@@ -67,3 +67,17 @@ def test_blocked_HessianLinearOperator_matmat(
 
     X = random.rand(op.shape[1], num_vecs)
     report_nonclose(op @ X, op_functorch @ X, atol=1e-6, rtol=5e-4)
+
+
+def test_HessianLinearOperator_dict(dict_case):
+    model_func, loss_func, params, data = dict_case
+    n_params = sum([p.numel() for p in params])
+
+    with raises(ValueError):
+        op = HessianLinearOperator(model_func, loss_func, params, data)
+
+    batch_size_fn = lambda data: data["x"].shape[0]
+    op = HessianLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    assert(op.shape == (n_params, n_params))

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -1,5 +1,6 @@
 """Contains tests for ``curvlinops/hessian``."""
 
+from collections.abc import MutableMapping
 from numpy import random
 from pytest import mark, raises
 from torch import block_diag
@@ -11,8 +12,22 @@ from curvlinops.utils import split_list
 
 
 def test_HessianLinearOperator_matvec(case, adjoint: bool):
-    op = HessianLinearOperator(*case)
-    op_functorch = functorch_hessian(*case).detach().cpu().numpy()
+    model_func, loss_func, params, data, batch_size_fn = case
+
+    # Test when X is dict-like but batch_size_fn = None (default)
+    if isinstance(data[0][0], MutableMapping):
+        with raises(ValueError):
+            op = HessianLinearOperator(model_func, loss_func, params, data)
+
+    op = HessianLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    op_functorch = (
+        functorch_hessian(model_func, loss_func, params, data, "x")
+        .detach()
+        .cpu()
+        .numpy()
+    )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
 
@@ -21,8 +36,17 @@ def test_HessianLinearOperator_matvec(case, adjoint: bool):
 
 
 def test_HessianLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
-    op = HessianLinearOperator(*case)
-    op_functorch = functorch_hessian(*case).detach().cpu().numpy()
+    model_func, loss_func, params, data, batch_size_fn = case
+
+    op = HessianLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    op_functorch = (
+        functorch_hessian(model_func, loss_func, params, data, "x")
+        .detach()
+        .cpu()
+        .numpy()
+    )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
 
@@ -50,14 +74,21 @@ def test_blocked_HessianLinearOperator_matmat(
         blocking: Blocking scheme.
         num_vecs: Number of vectors to multiply with. Default is ``2``.
     """
-    model, loss_func, params, data = case
+    model_func, loss_func, params, data, batch_size_fn = case
     block_sizes = BLOCKING_FNS[blocking](params)
 
-    op = HessianLinearOperator(model, loss_func, params, data, block_sizes=block_sizes)
+    op = HessianLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        block_sizes=block_sizes,
+    )
 
     # compute the blocks with functorch and build the block diagonal matrix
     op_functorch = [
-        functorch_hessian(model, loss_func, params_block, data).detach()
+        functorch_hessian(model_func, loss_func, params_block, data, "x").detach()
         for params_block in split_list(params, block_sizes)
     ]
     op_functorch = block_diag(*op_functorch).cpu().numpy()
@@ -67,17 +98,3 @@ def test_blocked_HessianLinearOperator_matmat(
 
     X = random.rand(op.shape[1], num_vecs)
     report_nonclose(op @ X, op_functorch @ X, atol=1e-6, rtol=5e-4)
-
-
-def test_HessianLinearOperator_dict(dict_case):
-    model_func, loss_func, params, data = dict_case
-    n_params = sum([p.numel() for p in params])
-
-    with raises(ValueError):
-        op = HessianLinearOperator(model_func, loss_func, params, data)
-
-    batch_size_fn = lambda data: data["x"].shape[0]
-    op = HessianLinearOperator(
-        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
-    )
-    assert(op.shape == (n_params, n_params))

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -1,6 +1,7 @@
 """Contains tests for ``curvlinops/hessian``."""
 
 from collections.abc import MutableMapping
+
 from numpy import random
 from pytest import mark, raises
 from torch import block_diag

--- a/test/test_hessian.py
+++ b/test/test_hessian.py
@@ -24,7 +24,7 @@ def test_HessianLinearOperator_matvec(case, adjoint: bool):
         model_func, loss_func, params, data, batch_size_fn=batch_size_fn
     )
     op_functorch = (
-        functorch_hessian(model_func, loss_func, params, data, "x")
+        functorch_hessian(model_func, loss_func, params, data, input_key="x")
         .detach()
         .cpu()
         .numpy()
@@ -43,7 +43,7 @@ def test_HessianLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
         model_func, loss_func, params, data, batch_size_fn=batch_size_fn
     )
     op_functorch = (
-        functorch_hessian(model_func, loss_func, params, data, "x")
+        functorch_hessian(model_func, loss_func, params, data, input_key="x")
         .detach()
         .cpu()
         .numpy()
@@ -89,7 +89,9 @@ def test_blocked_HessianLinearOperator_matmat(
 
     # compute the blocks with functorch and build the block diagonal matrix
     op_functorch = [
-        functorch_hessian(model_func, loss_func, params_block, data, "x").detach()
+        functorch_hessian(
+            model_func, loss_func, params_block, data, input_key="x"
+        ).detach()
         for params_block in split_list(params, block_sizes)
     ]
     op_functorch = block_diag(*op_functorch).cpu().numpy()

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -1,6 +1,7 @@
 """Contains tests for ``curvlinops/inverse``."""
 
 from math import sqrt
+from test.utils import cast_input
 from typing import Iterable, List, Tuple, Union
 
 import torch
@@ -21,7 +22,6 @@ from curvlinops import (
 )
 from curvlinops.examples.functorch import functorch_ggn
 from curvlinops.examples.utils import report_nonclose
-from test.utils import cast_input
 
 KFAC_MIN_DAMPING = 1e-8
 

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -590,7 +590,7 @@ def test_KFAC_inverse_damped_torch_matvec(
     x_list = [res.reshape(p.shape) for res, p in zip(split_x, KFAC._params)]
     inv_kfac_x_list = inv_KFAC.torch_matvec(x_list)
     inv_kfac_x_list = torch.cat([rearrange(M, "... -> (...)") for M in inv_kfac_x_list])
-    report_nonclose(inv_KFAC_x, inv_kfac_x_list.cpu().numpy())
+    report_nonclose(inv_KFAC_x.cpu().numpy(), inv_kfac_x_list.cpu().numpy())
 
     # Test against multiplication with dense matrix
     identity = torch.eye(inv_KFAC.shape[1], dtype=dtype, device=device)
@@ -599,4 +599,4 @@ def test_KFAC_inverse_damped_torch_matvec(
     report_nonclose(inv_KFAC_x.cpu().numpy(), inv_KFAC_mat_x.cpu().numpy())
 
     # Test against _matmat
-    report_nonclose(inv_KFAC @ x, inv_KFAC_x.cpu().numpy())
+    report_nonclose(inv_KFAC @ x.cpu().numpy(), inv_KFAC_x.cpu().numpy())

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -37,7 +37,10 @@ def test_CG_inverse_damped_GGN_matvec(case, delta: float = 2e-2):
 
     inv_GGN = CGInverseLinearOperator(GGN + damping)
     inv_GGN_functorch = inv(
-        functorch_ggn(model_func, loss_func, params, data, "x").detach().cpu().numpy()
+        functorch_ggn(model_func, loss_func, params, data, input_key="x")
+        .detach()
+        .cpu()
+        .numpy()
         + delta * eye(GGN.shape[1])
     )
 
@@ -74,7 +77,7 @@ def test_Neumann_inverse_damped_GGN_matvec(case, delta: float = 1e-2):
     damping = aslinearoperator(delta * sparse.eye(GGN.shape[0]))
 
     damped_GGN_functorch = functorch_ggn(
-        model_func, loss_func, params, data, "x"
+        model_func, loss_func, params, data, input_key="x"
     ).detach().cpu().numpy() + delta * eye(GGN.shape[1])
     inv_GGN_functorch = inv(damped_GGN_functorch)
 

--- a/test/test_jacobian.py
+++ b/test/test_jacobian.py
@@ -20,7 +20,10 @@ def test_JacobianLinearOperator_matvec(case, adjoint: bool):
 
     op = JacobianLinearOperator(model_func, params, data, batch_size_fn=batch_size_fn)
     op_functorch = (
-        functorch_jacobian(model_func, params, data, "x").detach().cpu().numpy()
+        functorch_jacobian(model_func, params, data, input_key="x")
+        .detach()
+        .cpu()
+        .numpy()
     )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
@@ -34,7 +37,10 @@ def test_JacobianLinearOperator_matmat(case, adjoint: bool, num_vecs: int = 3):
 
     op = JacobianLinearOperator(model_func, params, data, batch_size_fn=batch_size_fn)
     op_functorch = (
-        functorch_jacobian(model_func, params, data, "x").detach().cpu().numpy()
+        functorch_jacobian(model_func, params, data, input_key="x")
+        .detach()
+        .cpu()
+        .numpy()
     )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
@@ -55,7 +61,11 @@ def test_TransposedJacobianLinearOperator_matvec(case, adjoint: bool):
         model_func, params, data, batch_size_fn=batch_size_fn
     )
     op_functorch = (
-        functorch_jacobian(model_func, params, data, "x").detach().cpu().numpy().T
+        functorch_jacobian(model_func, params, data, input_key="x")
+        .detach()
+        .cpu()
+        .numpy()
+        .T
     )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T
@@ -73,7 +83,11 @@ def test_TransposedJacobianLinearOperator_matmat(
         model_func, params, data, batch_size_fn=batch_size_fn
     )
     op_functorch = (
-        functorch_jacobian(model_func, params, data, "x").detach().cpu().numpy().T
+        functorch_jacobian(model_func, params, data, input_key="x")
+        .detach()
+        .cpu()
+        .numpy()
+        .T
     )
     if adjoint:
         op, op_functorch = op.adjoint(), op_functorch.conj().T

--- a/test/test_jacobian.py
+++ b/test/test_jacobian.py
@@ -1,6 +1,7 @@
 """Contains tests for ``curvlinops/jacobian``."""
 
 from collections.abc import MutableMapping
+
 from numpy import random
 from pytest import raises
 

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -232,7 +232,7 @@ def test_kfac_one_datum(
         Union[BCEWithLogitsLoss, CrossEntropyLoss],
         List[Parameter],
         Iterable[Tuple[Tensor, Tensor]],
-    ]
+    ],
 ):
     model, loss_func, params, data, batch_size_fn = kfac_exact_one_datum_case
     loss_average = None if loss_func.reduction == "sum" else "batch"
@@ -260,7 +260,7 @@ def test_kfac_mc_one_datum(
         Union[BCEWithLogitsLoss, CrossEntropyLoss],
         List[Parameter],
         Iterable[Tuple[Tensor, Tensor]],
-    ]
+    ],
 ):
     model, loss_func, params, data, batch_size_fn = kfac_exact_one_datum_case
     loss_average = None if loss_func.reduction == "sum" else "batch"
@@ -291,7 +291,7 @@ def test_kfac_ef_one_datum(
         Union[BCEWithLogitsLoss, CrossEntropyLoss],
         List[Parameter],
         Iterable[Tuple[Tensor, Tensor]],
-    ]
+    ],
 ):
     model, loss_func, params, data, batch_size_fn = kfac_exact_one_datum_case
     loss_average = None if loss_func.reduction == "sum" else "batch"

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -995,3 +995,17 @@ def test_forward_only_fisher_type_exact_weight_sharing_case(
     # Check that input covariances were not computed
     if exclude == "weight":
         assert len(foof._input_covariances) == 0
+
+
+def test_KFACLinearOperator_dict(dict_case):
+    model_func, loss_func, params, data = dict_case
+    n_params = sum([p.numel() for p in params])
+
+    with raises(ValueError):
+        op = KFACLinearOperator(model_func, loss_func, params, data)
+
+    batch_size_fn = lambda data: data["x"].shape[0]
+    op = KFACLinearOperator(
+        model_func, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+    assert(op.shape == (n_params, n_params))

--- a/test/test_submatrix_on_curvatures.py
+++ b/test/test_submatrix_on_curvatures.py
@@ -68,7 +68,12 @@ def setup_submatrix_linear_operator(case, operator_case, submatrix_case):
 
     if operator_case == EFLinearOperator:
         A_functorch = CURVATURE_IN_FUNCTORCH[operator_case](
-            model_func, loss_func, params, data, batch_size_fn, "x"
+            model_func,
+            loss_func,
+            params,
+            data,
+            batch_size_fn=batch_size_fn,
+            input_key="x",
         )
     else:
         A_functorch = CURVATURE_IN_FUNCTORCH[operator_case](

--- a/test/test_submatrix_on_curvatures.py
+++ b/test/test_submatrix_on_curvatures.py
@@ -58,15 +58,22 @@ SUBMATRIX_IDS = [
 
 
 def setup_submatrix_linear_operator(case, operator_case, submatrix_case):
-    _, _, params, _ = case
+    model_func, loss_func, params, data, batch_size_fn = case
     dim = sum(p.numel() for p in params)
     row_idxs = submatrix_case["row_idx_fn"](dim)
     col_idxs = submatrix_case["col_idx_fn"](dim)
 
-    A = operator_case(*case)
+    A = operator_case(model_func, loss_func, params, data, batch_size_fn=batch_size_fn)
     A_sub = SubmatrixLinearOperator(A, row_idxs, col_idxs)
 
-    A_functorch = CURVATURE_IN_FUNCTORCH[operator_case](*case)
+    if operator_case == EFLinearOperator:
+        A_functorch = CURVATURE_IN_FUNCTORCH[operator_case](
+            model_func, loss_func, params, data, batch_size_fn, "x"
+        )
+    else:
+        A_functorch = CURVATURE_IN_FUNCTORCH[operator_case](
+            model_func, loss_func, params, data, "x"
+        )
     A_sub_functorch = A_functorch[row_idxs, :][:, col_idxs].detach().cpu().numpy()
 
     return A_sub, A_sub_functorch, row_idxs, col_idxs
@@ -99,4 +106,4 @@ def test_SubmatrixLinearOperator_on_curvatures_matmat(
     A_sub_X = A_sub @ X
 
     assert A_sub_X.shape == (len(row_idxs), num_vecs)
-    report_nonclose(A_sub_X, A_sub_functorch @ X, atol=5e-7)
+    report_nonclose(A_sub_X, A_sub_functorch @ X, atol=6e-7)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,8 +1,8 @@
 """Utility functions to test ``curvlinops``."""
 
-from collections.abc import Callable, MutableMapping
+from collections.abc import MutableMapping
 from itertools import product
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 from einops import reduce
 from einops.layers.torch import Rearrange

--- a/test/utils.py
+++ b/test/utils.py
@@ -79,7 +79,7 @@ def ggn_block_diagonal(
         loss_func: The loss function.
         params: The parameters w.r.t. which the GGN block-diagonals will be computed.
         data: A data loader.
-        batch_size_fn: A function that returns the batch size of given a dict-like ``X``.
+        batch_size_fn: A function that returns the batch size given a dict-like ``X``.
         separate_weight_and_bias: Whether to treat weight and bias of a layer as
             separate blocks in the block-diagonal GGN. Default: ``True``.
 
@@ -278,3 +278,17 @@ def cast_input(
         X = X.to(target_dtype)
 
     return X
+
+
+def batch_size_fn(X: MutableMapping) -> int:
+    """Get the batch size of a tensor wrapped in a dict-like object.
+
+    Assumes that the key to that tensor is "x".
+
+    Args:
+        X: The dict-like object with key "x" and a corresponding tensor value.
+
+    Returns:
+        batch_size: The first dimension size of the tensor.
+    """
+    return X["x"].shape[0]


### PR DESCRIPTION
Closes #86

@f-dangel @runame please give feedback and answer the question below. 

***Assumption:***

``` python
data: Union[Iterable[Tuple[Tensor, Tensor]], Iterable[Tuple[UserDict, Tensor]], Iterable[Tuple[dict, Tensor]]]
```
and there is an additional parameter in `_base._LinearOperator`:
``` python
batch_size_fn: Optional[Callable[[Any], int]] = None
```
where it must be non-`None` whenever `X` is not a `torch.Tensor`. 

This also fits well with Huggingface, although one must replace HF's default dataloader to outputs `(data, data['labels'])` instead of just `data`. Let me know if this should be considered.


***Code for testing the functionality:***

https://gist.github.com/wiseodd/426061afae24199446e60bfabc00e26e
I use `laplace-torch` there (two birds one stone), so just remove it if you don't want to install it. If you want to test `laplace-torch`, install via 
``` bash
pip install git+https://github.com/aleximmer/Laplace.git@mc-subset2
```