### PR TITLE
[REF] Make KFAC computation side effect free

### DIFF
--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -513,7 +513,6 @@ class KFACLinearOperator(_LinearOperator):
             self._compute_loss_and_backward(output, y)
 
         # clean up
-        self._model_func.zero_grad()
         for handle in hook_handles:
             handle.remove()
 


### PR DESCRIPTION
Before this PR, we call `.backward()` on a tensor to trigger the backward hooks that compute the grad-output-based Kronecker factors of KFAC. 
As a side effect, this will compute `.grad` of all leafs of the tensor we are differentiating.
This is problematic for use cases in optimization that use the `.grad` attribute, which is modified though by creating a `KFACLinearOperator`. 
This PR changes the `.backward()` calls into `autograd.grad(...)` which does not modify any `.grad` attributes and therefore makes the computation of KFAC side effect free.