### PR TITLE
[ADD] `state_dict` functionality to `KFACLinearOperator` and `KFACInverseLinearOperator`

### DIFF
--- a/curvlinops/inverse.py
+++ b/curvlinops/inverse.py
@@ -1,7 +1,7 @@
 """Implements linear operator inverses."""
 
 from math import sqrt
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from warnings import warn
 
 from einops import einsum, rearrange
@@ -695,3 +695,70 @@ class KFACInverseLinearOperator(_InverseLinearOperator):
         M_torch = self._A._preprocess(M)
         M_torch = self.torch_matmat(M_torch)
         return self._A._postprocess(M_torch)
+
+    def state_dict(self) -> Dict[str, Any]:
+        """Return the state of the inverse KFAC linear operator.
+
+        Returns:
+            State dictionary.
+        """
+        return {
+            "A": self._A.state_dict(),
+            # Attributes
+            "damping": self._damping,
+            "use_heuristic_damping": self._use_heuristic_damping,
+            "min_damping": self._min_damping,
+            "use_exact_damping": self._use_exact_damping,
+            "cache": self._cache,
+            "retry_double_precision": self._retry_double_precision,
+            # Inverse Kronecker factors (if computed and cached)
+            "inverse_input_covariances": self._inverse_input_covariances,
+            "inverse_gradient_covariances": self._inverse_gradient_covariances,
+        }
+
+    def load_state_dict(self, state_dict: Dict[str, Any]):
+        """Load the state of the inverse KFAC linear operator.
+
+        Args:
+            state_dict: State dictionary.
+        """
+        self._A.load_state_dict(state_dict["A"])
+
+        # Set attributes
+        self._damping = state_dict["damping"]
+        self._use_heuristic_damping = state_dict["use_heuristic_damping"]
+        self._min_damping = state_dict["min_damping"]
+        self._use_exact_damping = state_dict["use_exact_damping"]
+        self._cache = state_dict["cache"]
+        self._retry_double_precision = state_dict["retry_double_precision"]
+
+        # Set inverse Kronecker factors (if computed and cached)
+        self._inverse_input_covariances = state_dict["inverse_input_covariances"]
+        self._inverse_gradient_covariances = state_dict["inverse_gradient_covariances"]
+
+    @classmethod
+    def from_state_dict(
+        cls,
+        state_dict: Dict[str, Any],
+        A: KFACLinearOperator,
+    ) -> "KFACInverseLinearOperator":
+        """Load an inverse KFAC linear operator from a state dictionary.
+
+        Args:
+            state_dict: State dictionary.
+            A: ``KFACLinearOperator`` whose inverse is formed.
+
+        Returns:
+            Linear operator of inverse KFAC approximation.
+        """
+        inv_kfac = cls(
+            A,
+            damping=state_dict["damping"],
+            use_heuristic_damping=state_dict["use_heuristic_damping"],
+            min_damping=state_dict["min_damping"],
+            use_exact_damping=state_dict["use_exact_damping"],
+            cache=state_dict["cache"],
+            retry_double_precision=state_dict["retry_double_precision"],
+        )
+        inv_kfac.load_state_dict(state_dict)
+        return inv_kfac

--- a/curvlinops/inverse.py
+++ b/curvlinops/inverse.py
@@ -738,9 +738,7 @@ class KFACInverseLinearOperator(_InverseLinearOperator):
 
     @classmethod
     def from_state_dict(
-        cls,
-        state_dict: Dict[str, Any],
-        A: KFACLinearOperator,
+        cls, state_dict: Dict[str, Any], A: KFACLinearOperator
     ) -> "KFACInverseLinearOperator":
         """Load an inverse KFAC linear operator from a state dictionary.
 

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -1148,6 +1148,23 @@ class KFACLinearOperator(_LinearOperator):
         self._N_data = state_dict["num_data"]
 
         # Set Kronecker factors (if computed)
+        if self._input_covariances or self._gradient_covariances:
+            # If computed, check if the keys match the mapping keys
+            input_covariances_keys = set(self._input_covariances.keys())
+            gradient_covariances_keys = set(self._gradient_covariances.keys())
+            mapping_keys = set(self._mapping.keys())
+            if (
+                input_covariances_keys != mapping_keys
+                or gradient_covariances_keys != mapping_keys
+            ):
+                raise ValueError(
+                    "Input or gradient covariance keys in state dict do not match "
+                    "mapping keys of linear operator. "
+                    "Difference between input covariance and mapping keys: "
+                    f"{input_covariances_keys - mapping_keys}. "
+                    "Difference between gradient covariance and mapping keys: "
+                    f"{gradient_covariances_keys - mapping_keys}."
+                )
         self._input_covariances = state_dict["input_covariances"]
         self._gradient_covariances = state_dict["gradient_covariances"]
 

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -1089,7 +1089,7 @@ class KFACLinearOperator(_LinearOperator):
             "loss_reduction": self._loss_func.reduction,
             # Attributes
             "progressbar": self._progressbar,
-            "shape": self._shape,
+            "shape": self.shape,
             "seed": self._seed,
             "fisher_type": self._fisher_type,
             "mc_samples": self._mc_samples,
@@ -1137,7 +1137,7 @@ class KFACLinearOperator(_LinearOperator):
 
         # Set attributes
         self._progressbar = state_dict["progressbar"]
-        self._shape = state_dict["shape"]
+        self.shape = state_dict["shape"]
         self._seed = state_dict["seed"]
         self._fisher_type = state_dict["fisher_type"]
         self._mc_samples = state_dict["mc_samples"]
@@ -1182,6 +1182,9 @@ class KFACLinearOperator(_LinearOperator):
 
         Returns:
             Linear operator of KFAC approximation.
+
+        Raises:
+            RuntimeError: If the check for deterministic behavior fails.
         """
         loss_func = {
             "MSELoss": MSELoss,

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -683,10 +683,10 @@ def test_KFAC_inverse_save_and_load_state_dict():
     # save state dict
     state_dict = inv_kfac.state_dict()
 
+    # create new inverse KFAC with different linop input and try to load state dict
+    wrong_kfac = KFACLinearOperator(model, CrossEntropyLoss(), params, [(X, y)])
+    inv_kfac_wrong = KFACInverseLinearOperator(wrong_kfac)
     with raises(ValueError, match="mismatch"):
-        # create new inverse KFAC with different linop input and try to load state dict
-        wrong_kfac = KFACLinearOperator(model, CrossEntropyLoss(), params, [(X, y)])
-        inv_kfac_wrong = KFACInverseLinearOperator(wrong_kfac)
         inv_kfac_wrong.load_state_dict(state_dict)
 
     # create new inverse KFAC and load state dict

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -708,11 +708,11 @@ def test_KFAC_inverse_save_and_load_state_dict():
     wrong_kfac = KFACLinearOperator(model, CrossEntropyLoss(), params, [(X, y)])
     inv_kfac_wrong = KFACInverseLinearOperator(wrong_kfac)
     with raises(ValueError, match="mismatch"):
-        inv_kfac_wrong.load_state_dict(torch.load(state_dict))
+        inv_kfac_wrong.load_state_dict(torch.load("inv_kfac_state_dict.pt"))
 
     # create new inverse KFAC and load state dict
     inv_kfac_new = KFACInverseLinearOperator(kfac)
-    inv_kfac_new.load_state_dict(torch.load(state_dict))
+    inv_kfac_new.load_state_dict(torch.load("inv_kfac_state_dict.pt"))
 
     # check that the two inverse KFACs are equal
     compare_state_dicts(inv_kfac.state_dict(), inv_kfac_new.state_dict())

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -1286,6 +1286,9 @@ def test_save_and_load_state_dict():
     )
 
     # check that the two KFACs are equal
+    test_vec = rand(kfac.shape[1])
+    report_nonclose(kfac @ test_vec, kfac_new @ test_vec)
+
     assert len(kfac.state_dict()) == len(kfac_new.state_dict())
     for value, value_new in zip(
         kfac.state_dict().values(), kfac_new.state_dict().values()
@@ -1297,9 +1300,6 @@ def test_save_and_load_state_dict():
                 assert allclose(val, value_new[key])
         else:
             assert value == value_new
-
-    test_mat = rand(kfac.shape[1])
-    report_nonclose(kfac @ test_mat, kfac_new @ test_mat)
 
 
 def test_from_state_dict():
@@ -1327,6 +1327,9 @@ def test_from_state_dict():
     kfac_new = KFACLinearOperator.from_state_dict(state_dict, model, params, [(X, y)])
 
     # check that the two KFACs are equal
+    test_vec = rand(kfac.shape[1])
+    report_nonclose(kfac @ test_vec, kfac_new @ test_vec)
+
     assert len(kfac.state_dict()) == len(kfac_new.state_dict())
     for value, value_new in zip(
         kfac.state_dict().values(), kfac_new.state_dict().values()
@@ -1338,6 +1341,3 @@ def test_from_state_dict():
                 assert allclose(val, value_new[key])
         else:
             assert value == value_new
-
-    test_mat = rand(kfac.shape[1])
-    report_nonclose(kfac @ test_mat, kfac_new @ test_mat)

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -1253,7 +1253,7 @@ def test_save_and_load_state_dict():
         [(X, y)],
     )
     with raises(ValueError, match="loss"):
-        kfac_new.load_state_dict(load(state_dict))
+        kfac_new.load_state_dict(load("kfac_state_dict.pt"))
 
     # create new KFAC with different loss reduction and try to load state dict
     kfac_new = KFACLinearOperator(
@@ -1263,7 +1263,7 @@ def test_save_and_load_state_dict():
         [(X, y)],
     )
     with raises(ValueError, match="reduction"):
-        kfac_new.load_state_dict(load(state_dict))
+        kfac_new.load_state_dict(load("kfac_state_dict.pt"))
 
     # create new KFAC with different model and try to load state dict
     wrong_model = Sequential(Linear(D_in, 10), ReLU(), Linear(10, D_out))
@@ -1276,7 +1276,7 @@ def test_save_and_load_state_dict():
         loss_average=None,
     )
     with raises(RuntimeError, match="loading state_dict"):
-        kfac_new.load_state_dict(load(state_dict))
+        kfac_new.load_state_dict(load("kfac_state_dict.pt"))
 
     # create new KFAC and load state dict
     kfac_new = KFACLinearOperator(
@@ -1287,7 +1287,7 @@ def test_save_and_load_state_dict():
         loss_average=None,
         check_deterministic=False,  # turn off to avoid computing KFAC again
     )
-    kfac_new.load_state_dict(load(state_dict))
+    kfac_new.load_state_dict(load("kfac_state_dict.pt"))
 
     # check that the two KFACs are equal
     assert len(kfac.state_dict()) == len(kfac_new.state_dict())

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -1243,37 +1243,37 @@ def test_save_and_load_state_dict():
     # save state dict
     state_dict = kfac.state_dict()
 
+    # create new KFAC with different loss function and try to load state dict
+    kfac_new = KFACLinearOperator(
+        model,
+        CrossEntropyLoss(),
+        params,
+        [(X, y)],
+    )
     with raises(ValueError, match="loss"):
-        # create new KFAC with different loss function and try to load state dict
-        kfac_new = KFACLinearOperator(
-            model,
-            CrossEntropyLoss(),
-            params,
-            [(X, y)],
-        )
         kfac_new.load_state_dict(state_dict)
 
+    # create new KFAC with different loss reduction and try to load state dict
+    kfac_new = KFACLinearOperator(
+        model,
+        MSELoss(),
+        params,
+        [(X, y)],
+    )
     with raises(ValueError, match="reduction"):
-        # create new KFAC with different loss reduction and try to load state dict
-        kfac_new = KFACLinearOperator(
-            model,
-            MSELoss(),
-            params,
-            [(X, y)],
-        )
         kfac_new.load_state_dict(state_dict)
 
+    # create new KFAC with different model and try to load state dict
+    wrong_model = Sequential(Linear(D_in, 10), ReLU(), Linear(10, D_out))
+    wrong_params = list(wrong_model.parameters())
+    kfac_new = KFACLinearOperator(
+        wrong_model,
+        MSELoss(reduction="sum"),
+        wrong_params,
+        [(X, y)],
+        loss_average=None,
+    )
     with raises(RuntimeError, match="loading state_dict"):
-        # create new KFAC with different model and try to load state dict
-        wrong_model = Sequential(Linear(D_in, 10), ReLU(), Linear(10, D_out))
-        wrong_params = list(wrong_model.parameters())
-        kfac_new = KFACLinearOperator(
-            wrong_model,
-            MSELoss(reduction="sum"),
-            wrong_params,
-            [(X, y)],
-            loss_average=None,
-        )
         kfac_new.load_state_dict(state_dict)
 
     # create new KFAC and load state dict


### PR DESCRIPTION
Resolves #113.

I don't know if this covers all edge cases, but hopefully at least the most common use cases. For example, it is assumed that the user passes the right `params`, not sure if this can be avoided or if it is likely to lead to problems.