### PR TITLE
[REF] Deprecate `pkg_resources`, use `importlib` & `packaging`

### DIFF
--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade packaging
-        pip show packaging
+        python -m pip show packaging
         make install-lint
     - name: Run black
       run: |

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install --upgrade wheel
         python -m pip install --upgrade packaging
         python -m pip show packaging
         make install-lint

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -14,16 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.10
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: '3.10'
+        python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade wheel
-        python -m pip install --upgrade packaging
-        python -m pip show packaging
+        python -m pip install --upgrade pip wheel
         make install-lint
     - name: Run black
       run: |

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging
+        python -m pip install packaging
         make install-lint
     - name: Run black
       run: |

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install packaging
         make install-lint
     - name: Run black
       run: |

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -20,7 +20,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel packaging
         make install-lint
     - name: Run black
       run: |

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install packaging
+        sudo apt-get install python3-packaging
         make install-lint
     - name: Run black
       run: |

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -21,7 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        sudo apt-get install python3-packaging
+        python -m pip install --upgrade packaging
+        pip show packaging
         make install-lint
     - name: Run black
       run: |

--- a/.github/workflows/lint-darglint.yaml
+++ b/.github/workflows/lint-darglint.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging
+        python -m pip install packaging
         make install-lint
     - name: Run darglint
       run: |

--- a/.github/workflows/lint-darglint.yaml
+++ b/.github/workflows/lint-darglint.yaml
@@ -20,8 +20,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install packaging
+        python -m pip install --upgrade pip wheel
         make install-lint
     - name: Run darglint
       run: |

--- a/.github/workflows/lint-darglint.yaml
+++ b/.github/workflows/lint-darglint.yaml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install packaging
         make install-lint
     - name: Run darglint
       run: |

--- a/.github/workflows/lint-darglint.yaml
+++ b/.github/workflows/lint-darglint.yaml
@@ -20,7 +20,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel packaging
         make install-lint
     - name: Run darglint
       run: |

--- a/.github/workflows/lint-flake8.yaml
+++ b/.github/workflows/lint-flake8.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging
+        python -m pip install packaging
         make install-lint
     - name: Run flake8
       run: |

--- a/.github/workflows/lint-flake8.yaml
+++ b/.github/workflows/lint-flake8.yaml
@@ -19,8 +19,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install packaging
+        python -m pip install --upgrade pip wheel
         make install-lint
     - name: Run flake8
       run: |

--- a/.github/workflows/lint-flake8.yaml
+++ b/.github/workflows/lint-flake8.yaml
@@ -20,6 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install packaging
         make install-lint
     - name: Run flake8
       run: |

--- a/.github/workflows/lint-flake8.yaml
+++ b/.github/workflows/lint-flake8.yaml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel packaging
         make install-lint
     - name: Run flake8
       run: |

--- a/.github/workflows/lint-isort.yaml
+++ b/.github/workflows/lint-isort.yaml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install packaging
         make install-lint
     - name: Run isort
       run: |

--- a/.github/workflows/lint-isort.yaml
+++ b/.github/workflows/lint-isort.yaml
@@ -20,7 +20,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel packaging
         make install-lint
     - name: Run isort
       run: |

--- a/.github/workflows/lint-isort.yaml
+++ b/.github/workflows/lint-isort.yaml
@@ -20,8 +20,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install packaging
+        python -m pip install --upgrade pip wheel
         make install-lint
     - name: Run isort
       run: |

--- a/.github/workflows/lint-isort.yaml
+++ b/.github/workflows/lint-isort.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging
+        python -m pip install packaging
         make install-lint
     - name: Run isort
       run: |

--- a/.github/workflows/lint-pydocstyle.yaml
+++ b/.github/workflows/lint-pydocstyle.yaml
@@ -21,8 +21,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install packaging
+        python -m pip install --upgrade pip wheel
         make install-lint
     - name: Run pydocstyle
       run: |

--- a/.github/workflows/lint-pydocstyle.yaml
+++ b/.github/workflows/lint-pydocstyle.yaml
@@ -22,6 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install packaging
         make install-lint
     - name: Run pydocstyle
       run: |

--- a/.github/workflows/lint-pydocstyle.yaml
+++ b/.github/workflows/lint-pydocstyle.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging
+        python -m pip install packaging
         make install-lint
     - name: Run pydocstyle
       run: |

--- a/.github/workflows/lint-pydocstyle.yaml
+++ b/.github/workflows/lint-pydocstyle.yaml
@@ -21,7 +21,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel packaging
         make install-lint
     - name: Run pydocstyle
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install setuptools wheel twine packaging
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine packaging
+          python -m pip install setuptools wheel twine packaging
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools wheel twine
+          python -m pip install setuptools wheel twine packaging
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools wheel twine packaging
+          python -m pip install setuptools wheel twine
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         python-version: "${{ matrix.python-version }}"
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel packaging
         make install-test
     - name: Run test
       if: contains('refs/heads/master refs/heads/development', github.ref)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging
+        python -m pip install packaging
         make install-test
     - name: Run test
       if: contains('refs/heads/master refs/heads/development', github.ref)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install packaging
         make install-test
     - name: Run test
       if: contains('refs/heads/master refs/heads/development', github.ref)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,8 +25,7 @@ jobs:
         python-version: "${{ matrix.python-version }}"
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install packaging
+        python -m pip install --upgrade pip wheel
         make install-test
     - name: Run test
       if: contains('refs/heads/master refs/heads/development', github.ref)

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,8 @@ build:
   tools:
     python: "3.8"
   jobs:
-    post_build:
-    - pip install --upgrade packaging wheel
+    post_install:
+    - pip install --upgrade pip packaging wheel
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,11 +10,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
-  commands:
-    - pip install --upgrade pip wheel packaging
 
 python:
   install:
+  - method: pip
+    path: packaging
+  - method: pip
+    path: wheel
   - method: pip
     path: .
     extra_requirements:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   tools:
     python: "3.8"
   commands:
-    - pip install --upgrade wheels packaging
+    - pip install --upgrade pip wheels packaging
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,13 +10,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+  jobs:
+    post_build:
+    - pip install --upgrade packaging wheel
 
 python:
   install:
-  - method: pip
-    path: packaging
-  - method: pip
-    path: wheel
   - method: pip
     path: .
     extra_requirements:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.8"
   jobs:
     post_install:
-    - pip install --upgrade pip packaging wheel
+    - pip install --upgrade pip packaging wheel setuptools<=69
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,10 @@ build:
 python:
   install:
   - method: pip
+    path: wheels
+  - method: pip
+    path: packaging
+  - method: pip
     path: .
     extra_requirements:
       - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,13 +10,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+  commands:
+    - pip install --upgrade wheels packaging
 
 python:
   install:
-  - method: pip
-    path: wheels
-  - method: pip
-    path: packaging
   - method: pip
     path: .
     extra_requirements:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   tools:
     python: "3.8"
   commands:
-    - pip install --upgrade pip wheels packaging
+    - pip install --upgrade pip wheel packaging
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.8"
   jobs:
     post_install:
-    - pip install --upgrade pip packaging wheel setuptools<=69
+    - pip install --upgrade pip packaging wheel setuptools==69.5.1
 
 python:
   install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     tqdm>=4.61.0,<5.0.0
     einops
     einconv
+    packaging
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,6 @@ lint =
 
 # Dependencies needed to build/view the documentation (semicolon/line-separated)
 docs =
-    setuptools==69.5.1 # RTD fails with setuptools>=70, see https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863
     transformers
     datasets
     matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     tqdm>=4.61.0,<5.0.0
     einops
     einconv
-    packaging
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.8
 

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,15 @@ Use ``setup.cfg`` for configuration.
 """
 
 import sys
+from importlib.metadata import version
 
-from pkg_resources import VersionConflict, require
+from packaging.version import Version
 from setuptools import setup
 
-try:
-    require("setuptools>=38.3")
-except VersionConflict:
-    print("Error: version of setuptools is too old (<38.3)!")
+setuptools_version = Version(version("setuptools"))
+
+if setuptools_version < Version("38.3"):
+    print(f"Error: version of setuptools is too old (<38.3). Got {setuptools_version}.")
     sys.exit(1)
 
 


### PR DESCRIPTION
Had to explicitly install `packaging` and `wheels` in the CI because otherwise it would crash with an `ImportError` when trying to `import packaging` (note that only installing `packaging` was not sufficient).