### PR TITLE
[REQ] Deprecate python 3.8

### DIFF
--- a/.conda_env.yml
+++ b/.conda_env.yml
@@ -3,7 +3,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - pip=21.2.4
-  - python=3.8.5
+  - python=3.9.16
+  - pip=23.1.2
   - pip:
     - -e .[lint,test,docs]

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-darglint.yaml
+++ b/.github/workflows/lint-darglint.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-flake8.yaml
+++ b/.github/workflows/lint-flake8.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-isort.yaml
+++ b/.github/workflows/lint-isort.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-pydocstyle.yaml
+++ b/.github/workflows/lint-pydocstyle.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     env:
-      USING_COVERAGE: '3.8'
+      USING_COVERAGE: '3.9'
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 python:
   install:

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed/Removed
+
+- Deprecate Python 3.8 as it will reach its end of life in October 2024
+  ([PR](https://github.com/f-dangel/curvlinops/pull/128))
+
 ## [2.0.0] - 2024-08-15
 
 This major release is almost fully backward compatible with the `1.x.y` release

--- a/curvlinops/diagonal/hutchinson.py
+++ b/curvlinops/diagonal/hutchinson.py
@@ -50,7 +50,7 @@ class HutchinsonDiagonalEstimator:
         >>> error_high_precision = norm(diag_A - diag_A_high_precision)
         >>> assert error_low_precision > error_high_precision
         >>> round(error_low_precision, 4), round(error_high_precision, 4)
-        (5.7268, 0.1525)
+        (np.float64(5.7268), np.float64(0.1525))
     """
 
     def __init__(self, A: LinearOperator):

--- a/curvlinops/diagonal/hutchinson.py
+++ b/curvlinops/diagonal/hutchinson.py
@@ -50,7 +50,7 @@ class HutchinsonDiagonalEstimator:
         >>> error_high_precision = norm(diag_A - diag_A_high_precision)
         >>> assert error_low_precision > error_high_precision
         >>> round(error_low_precision, 4), round(error_high_precision, 4)
-        (np.float64(5.7268), np.float64(0.1525))
+        (5.7268, 0.1525)
     """
 
     def __init__(self, A: LinearOperator):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -45,7 +44,7 @@ dependencies = [
     "einconv",
 ]
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 ###############################################################################
 #                           Development dependencies                          #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "backpack-for-pytorch>=1.6.0,<2.0.0",
     "torch>=2.0",
     "scipy>=1.7.1,<2.0.0",
+    "numpy<2.0.0",
     "tqdm>=4.61.0,<5.0.0",
     "einops",
     "einconv",


### PR DESCRIPTION
Python 3.8 will reach its end of life in October 2024.
Therefore, we will deprecate it and require at least Python 3.9 in future releases.