### PR TITLE
Remove conversion of data Iterable to Iterator in `_LinearOperator`

### DIFF
--- a/curvlinops/_base.py
+++ b/curvlinops/_base.py
@@ -340,7 +340,7 @@ class _LinearOperator(LinearOperator):
         Yields:
             Mini-batches ``(X, y)``.
         """
-        data_iter = iter(self._data)
+        data_iter = self._data
 
         if self._progressbar:
             desc = f"{self.__class__.__name__}{'' if desc is None else f'.{desc}'}"


### PR DESCRIPTION
Addresses #135 by removing the conversion of the data iterable stored in `self._data` to and iterator with `iter()`.