### PR TITLE
[REF] Replicate base class, but inherit from PyTorch linear operator

### DIFF
--- a/curvlinops/_torch_base.py
+++ b/curvlinops/_torch_base.py
@@ -128,6 +128,9 @@ class PyTorchLinearOperator:
                 This is useful for post-processing the multiplication's result.
             is_vec: Whether the input is a vector or a matrix.
             num_vecs: The number of vectors represented by the input.
+
+        Raises:
+            ValueError: If the input format is invalid.
         """
         if isinstance(X, Tensor):
             list_format = False
@@ -295,10 +298,10 @@ class PyTorchLinearOperator:
     def _infer_device(self) -> device:
         """Infer the linear operator's device.
 
-        Returns:
+        Returns:  # noqa: D402
             The device of the linear operator.
 
-        Raises: # noqa: D402
+        Raises:
             NotImplementedError: Must be implemented by subclasses.
         """
         raise NotImplementedError
@@ -306,10 +309,10 @@ class PyTorchLinearOperator:
     def _infer_dtype(self) -> dtype:
         """Infer the linear operator's data type.
 
-        Returns:
+        Returns: # noqa: D402
             The data type of the linear operator.
 
-        Raises: # noqa: D402
+        Raises:
             NotImplementedError: Must be implemented by subclasses.
         """
         raise NotImplementedError

--- a/curvlinops/_torch_base.py
+++ b/curvlinops/_torch_base.py
@@ -507,7 +507,7 @@ class CurvatureLinearOperator(PyTorchLinearOperator):
 
     def _matmat_batch(
         self, X: Union[MutableMapping, Tensor], y: Tensor, M: List[Tensor]
-    ) -> Tuple[Tensor]:
+    ) -> List[Tensor]:
         """Apply the mini-batch matrix to a vector.
 
         Args:

--- a/curvlinops/_torch_base.py
+++ b/curvlinops/_torch_base.py
@@ -439,7 +439,7 @@ class CurvatureLinearOperator(PyTorchLinearOperator):
             )
 
         in_shape = [tuple(p.shape) for p in params] if in_shape is None else in_shape
-        out_shape = [tuple(p.shape) for p in params] if in_shape is None else in_shape
+        out_shape = [tuple(p.shape) for p in params] if out_shape is None else out_shape
         super().__init__(in_shape, out_shape)
 
         self._params = params
@@ -538,7 +538,7 @@ class CurvatureLinearOperator(PyTorchLinearOperator):
         Yields:
             Mini-batches ``(X, y)``.
         """
-        data_iter = iter(self._data)
+        data_iter = self._data
 
         if self._progressbar:
             desc = f"{self.__class__.__name__}{'' if desc is None else f'.{desc}'}"

--- a/curvlinops/_torch_base.py
+++ b/curvlinops/_torch_base.py
@@ -1,0 +1,346 @@
+"""Defines a minimal ``LinearOperator`` interface in PyTorch."""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Tuple, Union
+
+import numpy
+from scipy.sparse.linalg import LinearOperator
+from torch import Size, Tensor, cat, device, dtype, from_numpy
+
+
+class PyTorchLinearOperator:
+    """Interface for linear operators in PyTorch.
+
+    Heavily inspired by the Scipy interface
+    (https://github.com/scipy/scipy/blob/v1.13.1/scipy/sparse/linalg/_interface.py),
+    but only supports a sub-set of the functionality.
+
+    One main difference is that the linear operators cannot only multiply
+    vectors/matrices specified as single PyTorch tensors, but also
+    vectors/matrices specified in tensor list format. This is common in
+    PyTorch, where the space a linear operator acts on is a tensor product
+
+    Functions that need to be implemented are ``_matmat`` and ``_adjoint``.
+
+    The interface also supports exporting the PyTorch linear operator to a SciPy linear
+    operator, which can be useful for interfacing with SciPy routines. To achieve this,
+    the functions ``_infer_device`` and ``_infer_dtype`` must be implemented.
+
+    """
+
+    def __init__(
+        self, in_shape: List[Tuple[int, ...]], out_shape: List[Tuple[int, ...]]
+    ):
+        """Store the linear operator's input and output space dimensions.
+
+        Args:
+            in_shape: A list of shapes specifying the linear operator's input space.
+            out_shape: A list of shapes specifying the linear operator's output space.
+        """
+        self._in_shape = [Size(s) for s in in_shape]
+        self._out_shape = [Size(s) for s in out_shape]
+
+        self._in_shape_flat = [s.numel() for s in self._in_shape]
+        self._out_shape_flat = [s.numel() for s in self._out_shape]
+        self.shape = (sum(self._out_shape_flat), sum(self._in_shape_flat))
+
+    def __matmul__(self, X: Union[List[Tensor], Tensor]) -> Union[List[Tensor], Tensor]:
+        """Multiply onto a vector or matrix given as PyTorch tensor or tensor list.
+
+        Args:
+            X: A vector or matrix to multiply onto, represented as a single tensor or a
+                tensor list.
+
+                Assume the linear operator has total shape ``[M, N]``:
+                If ``X`` is a single tensor, it can be of shape ``[N, K]`` (matrix), or
+                ``[N]`` (vector). The result will have shape ``[M, K]`` or ``[M]``.
+
+                Instead, we can also pass ``X`` as tensor list:
+                Assume the linear operator's rows are formed by a list of shapes
+                ``[M1, M2, ...]`` and the columns by ``[N1, N2, ...]``, such that
+                ``M1.numel() + M2.numel() + ... = M`` and ``N1.numel() + N2.numel() +
+                ... = N``. Then, ``X`` can also be a list of tensors with shape
+                ``[*N1], [*N2], ...`` (vector) or ``[*N1, K], [*N2, K], ...`` (matrix).
+                In this case, the output will be tensor list with shapes ``[*M1], [*M2],
+                ...`` (vector) or ``[K, *M1], [K, *M2], ...`` (matrix).
+
+        Returns:
+            The result of the matrix-vector or matrix-matrix multiplication in the same
+            format as ``X``.
+        """
+        # convert to tensor list format
+        X, list_format, is_vec, num_vecs = self._check_input_and_preprocess(X)
+
+        # matrix-matrix-multiply using tensor list format
+        AX = self._matmat(X)
+
+        # return same format as ``X`` passed by the user
+        return self._check_output_and_postprocess(AX, list_format, is_vec, num_vecs)
+
+    def _matmat(self, X: List[Tensor]) -> List[Tensor]:
+        """Matrix-matrix multiplication.
+
+        Args:
+            X: A list of tensors representing the matrix to multiply onto.
+                The list must contain tensors of shape ``[*N1, K], [*N2, K], ...``,
+                where ``N1, N2, ...`` are the shapes of the linear operator's columns.
+
+        Returns: # noqa: D402
+            A list of tensors with shape ``[*M1, K], [*M2, K], ...``, where ``M1, M2,
+            ...`` are the shapes of the linear operator's rows.
+
+        Raises:
+            NotImplementedError: Must be implemented by the subclass.
+        """
+        raise NotImplementedError
+
+    def adjoint(self) -> PyTorchLinearOperator:
+        """Return the adjoint of the linear operator.
+
+        Returns:
+            The adjoint of the linear operator.
+        """
+        return self._adjoint()
+
+    def _adjoint(self) -> PyTorchLinearOperator:
+        """Adjoint of the linear operator.
+
+        Returns: # noqa: D402
+            The adjoint of the linear operator.
+
+        Raises:
+            NotImplementedError: Must be implemented by the subclass.
+        """
+        raise NotImplementedError
+
+    def _check_input_and_preprocess(
+        self, X: Union[List[Tensor], Tensor]
+    ) -> Tuple[List[Tensor], bool, bool, int]:
+        """Check input format and pre-process it to a matrix in tensor list format.
+
+        Args:
+            X: The object onto which the linear operator is multiplied.
+
+        Returns:
+            X_tensor_list: The input object in tensor list format.
+            list_format: Whether the input was specified in tensor list format.
+                This is useful for post-processing the multiplication's result.
+            is_vec: Whether the input is a vector or a matrix.
+            num_vecs: The number of vectors represented by the input.
+        """
+        if isinstance(X, Tensor):
+            list_format = False
+            X_tensor_list, is_vec, num_vecs = self.__check_tensor_and_preprocess(X)
+
+        elif isinstance(X, list) and all(isinstance(x, Tensor) for x in X):
+            list_format = True
+            X_tensor_list, is_vec, num_vecs = self.__check_tensor_list_and_preprocess(X)
+
+        else:
+            raise ValueError(f"Input must be tensor or list of tensors. Got {type(X)}.")
+
+        return X_tensor_list, list_format, is_vec, num_vecs
+
+    def __check_tensor_and_preprocess(
+        self, X: Tensor
+    ) -> Tuple[List[Tensor], bool, int]:
+        """Check single-tensor input format and process into a matrix tensor list.
+
+        Args:
+            X: The tensor onto which the linear operator is multiplied.
+
+        Returns:
+            X_processed: The input tensor as matrix in tensor list format.
+            is_vec: Whether the input is a vector or a matrix.
+            num_vecs: The number of vectors represented by the input.
+
+        Raises:
+            ValueError: If the input tensor has an invalid shape.
+        """
+        if X.ndim > 2 or X.shape[0] != self.shape[1]:
+            raise ValueError(
+                f"Input tensor must have shape ({self.shape[1]},) or "
+                + f"({self.shape[1]}, K), with K arbitrary. Got {X.shape}."
+            )
+
+        # determine whether the input is a vector or matrix
+        is_vec = X.ndim == 1
+        num_vecs = 1 if is_vec else X.shape[1]
+
+        # convert to matrix in tensor list format
+        X_processed = [
+            x.reshape(*s, num_vecs)
+            for x, s in zip(X.split(self._in_shape_flat), self._in_shape)
+        ]
+
+        return X_processed, is_vec, num_vecs
+
+    def __check_tensor_list_and_preprocess(
+        self, X: List[Tensor]
+    ) -> Tuple[List[Tensor], bool, int]:
+        """Check tensor list input format and process into a matrix tensor list.
+
+        Args:
+            X: The tensor list onto which the linear operator is multiplied.
+
+        Returns:
+            X_processed: The input as matrix in tensor list format.
+            is_vec: Whether the input is a vector or a matrix.
+            num_vecs: The number of vectors represented by the input.
+
+        Raises:
+            ValueError: If the tensor entries in the list have invalid shapes.
+        """
+        if len(X) != len(self._in_shape):
+            raise ValueError(
+                f"List must contain {len(self._in_shape)} tensors. Got {len(X)}."
+            )
+
+        # check if input is a vector or a matrix
+        if all(x.shape == s for x, s in zip(X, self._in_shape)):
+            is_vec, num_vecs = True, 1
+        elif (
+            all(
+                x.ndim == len(s) + 1 and x.shape[:-1] == s
+                for x, s in zip(X, self._in_shape)
+            )
+            and len({x.shape[-1] for x in X}) == 1
+        ):
+            is_vec, (num_vecs,) = False, {x.shape[-1] for x in X}
+        else:
+            raise ValueError(
+                f"Input list must contain tensors with shapes {self._in_shape} "
+                + "and optional trailing dimension for the matrix columns. "
+                + f"Got {[x.shape for x in X]}."
+            )
+
+        # convert to matrix in tensor list format
+        X_processed = [x.unsqueeze(-1) for x in X] if is_vec else X
+
+        return X_processed, is_vec, num_vecs
+
+    def _check_output_and_postprocess(
+        self, AX: List[Tensor], list_format: bool, is_vec: bool, num_vecs: int
+    ) -> Union[List[Tensor], Tensor]:
+        """Check multiplication output and post-process it to the original format.
+
+        Args:
+            AX: The output of the multiplication as matrix in tensor list format.
+            list_format: Whether the output should be in tensor list format.
+            is_vec: Whether the output should be a vector or a matrix.
+            num_vecs: The number of vectors represented by the output.
+
+        Returns:
+            AX_processed: The output in the original format, either as single tensor
+                or list of tensors.
+
+        Raises:
+            ValueError: If the output tensor list has an invalid length or shape.
+        """
+        # verify output tensor list format
+        if len(AX) != len(self._out_shape):
+            raise ValueError(
+                f"Output list must contain {len(self._out_shape)} tensors. Got {len(AX)}."
+            )
+        if any(Ax.shape != (*s, num_vecs) for Ax, s in zip(AX, self._out_shape)):
+            raise ValueError(
+                f"Output tensors must have shapes {self._out_shape} and additional "
+                + f"trailing dimension of {num_vecs}. "
+                + f"Got {[Ax.shape for Ax in AX]}."
+            )
+
+        if list_format:
+            AX_processed = [Ax.squeeze(-1) for Ax in AX] if is_vec else AX
+        else:
+            AX_processed = cat(
+                [Ax.reshape(s, num_vecs) for Ax, s in zip(AX, self._out_shape_flat)]
+            )
+            AX_processed = AX_processed.squeeze(-1) if is_vec else AX_processed
+
+        return AX_processed
+
+    ###############################################################################
+    #                                 SCIPY EXPORT                                #
+    ###############################################################################
+
+    def to_scipy(self, dtype: Optional[numpy.dtype] = None) -> LinearOperator:
+        """Wrap the PyTorch linear operator with a SciPy linear operator.
+
+        Args:
+            dtype: The data type of the SciPy linear operator. If ``None``, uses
+                NumPy's default data dtype.
+
+
+        Returns:
+            A SciPy linear operator that carries out the matrix-vector products
+            in PyTorch.
+        """
+        dev = self._infer_device()
+        dt = self._infer_dtype()
+
+        scipy_matmat = self._scipy_compatible(self.__matmul__, dev, dt)
+        A_adjoint = self.adjoint()
+        scipy_rmatmat = A_adjoint._scipy_compatible(A_adjoint.__matmul__, dev, dt)
+
+        return LinearOperator(
+            self.shape,
+            matvec=scipy_matmat,
+            rmatvec=scipy_rmatmat,
+            matmat=scipy_matmat,
+            rmatmat=scipy_rmatmat,
+            dtype=numpy.dtype(dtype) if dtype is None else dtype,
+        )
+
+    def _infer_device(self) -> device:
+        """Infer the linear operator's device.
+
+        Returns:
+            The device of the linear operator.
+
+        Raises: # noqa: D402
+            NotImplementedError: Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def _infer_dtype(self) -> dtype:
+        """Infer the linear operator's data type.
+
+        Returns:
+            The data type of the linear operator.
+
+        Raises: # noqa: D402
+            NotImplementedError: Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _scipy_compatible(
+        f: Callable[[Tensor], Tensor], device: device, dtype: dtype
+    ) -> Callable[[numpy.ndarray], numpy.ndarray]:
+        """Wrap a PyTorch matrix multiplication function to be compatible with SciPy.
+
+        Args:
+            f: The PyTorch matrix multiplication function.
+            device: The device on which the PyTorch linear operator is defined.
+            dtype: The data type of the PyTorch linear operator.
+
+        Returns:
+            A function that takes a NumPy array and returns a NumPy array.
+        """
+
+        def f_scipy(X: numpy.ndarray) -> numpy.ndarray:
+            """Scipy-compatible matrix multiplication function.
+
+            Args:
+                X: The input matrix in NumPy format.
+
+            Returns:
+                The output matrix in NumPy format.
+            """
+            X_dtype = X.dtype
+            X_torch = from_numpy(X).to(device, dtype)
+            AX_torch = f(X_torch)
+            return AX_torch.detach().cpu().numpy().astype(X_dtype)
+
+        return f_scipy

--- a/curvlinops/_torch_base.py
+++ b/curvlinops/_torch_base.py
@@ -6,18 +6,7 @@ from typing import Callable, Iterable, List, MutableMapping, Optional, Tuple, Un
 
 import numpy
 from scipy.sparse.linalg import LinearOperator
-from torch import (
-    Size,
-    Tensor,
-    as_tensor,
-    cat,
-    device,
-    dtype,
-    from_numpy,
-    rand,
-    tensor,
-    zeros_like,
-)
+from torch import Size, Tensor, as_tensor, cat, device, dtype, rand, tensor, zeros_like
 from torch.autograd import grad
 from torch.nn import Module, Parameter
 from tqdm import tqdm

--- a/curvlinops/utils.py
+++ b/curvlinops/utils.py
@@ -3,7 +3,7 @@
 from typing import List
 
 from numpy import cumsum
-from torch import Tensor, logical_not
+from torch import Tensor
 
 
 def split_list(x: List, sizes: List[int]) -> List[List]:

--- a/curvlinops/utils.py
+++ b/curvlinops/utils.py
@@ -28,14 +28,16 @@ def split_list(x: List, sizes: List[int]) -> List[List]:
     return [x[boundaries[i] : boundaries[i + 1]] for i in range(len(sizes))]
 
 
-def allclose_report(tensor1: Tensor, tensor2: Tensor, rtol: float, atol: float) -> bool:
+def allclose_report(
+    tensor1: Tensor, tensor2: Tensor, rtol: float = 1e-5, atol: float = 1e-8
+) -> bool:
     """Same as ``allclose``, but prints entries that differ.
 
     Args:
         tensor1: First tensor for comparison.
         tensor2: Second tensor for comparison.
-        rtol: Relative tolerance.
-        atol: Absolute tolerance.
+        rtol: Relative tolerance. Default is ``1e-5``.
+        atol: Absolute tolerance. Default is ``1e-8``.
 
     Returns:
         ``True`` if the tensors are close, ``False`` otherwise.

--- a/curvlinops/utils.py
+++ b/curvlinops/utils.py
@@ -3,6 +3,7 @@
 from typing import List
 
 from numpy import cumsum
+from torch import Tensor, logical_not
 
 
 def split_list(x: List, sizes: List[int]) -> List[List]:
@@ -25,3 +26,28 @@ def split_list(x: List, sizes: List[int]) -> List[List]:
         )
     boundaries = cumsum([0] + sizes)
     return [x[boundaries[i] : boundaries[i + 1]] for i in range(len(sizes))]
+
+
+def allclose_report(tensor1: Tensor, tensor2: Tensor, rtol: float, atol: float) -> bool:
+    """Same as ``allclose``, but prints entries that differ.
+
+    Args:
+        tensor1: First tensor for comparison.
+        tensor2: Second tensor for comparison.
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+
+    Returns:
+        ``True`` if the tensors are close, ``False`` otherwise.
+    """
+    close = tensor1.allclose(tensor2, rtol=rtol, atol=atol)
+    if not close:
+        nonclose_idx = tensor1.isclose(tensor2, rtol=rtol, atol=atol).logical_not_()
+        for idx, t1, t2 in zip(
+            nonclose_idx.argwhere(),
+            tensor1[nonclose_idx].flatten(),
+            tensor2[nonclose_idx].flatten(),
+        ):
+            print(f"at index {idx}: {t1:.5e} ≠ {t2:.5e}, ratio: {t1 / t2:.5e}")
+
+    return close

--- a/docs/examples/basic_usage/example_inverses.py
+++ b/docs/examples/basic_usage/example_inverses.py
@@ -33,7 +33,7 @@ from curvlinops import (
     GGNLinearOperator,
     NeumannInverseLinearOperator,
 )
-from curvlinops.examples.functorch import functorch_ggn, functorch_gradient
+from curvlinops.examples.functorch import functorch_ggn, functorch_gradient_and_loss
 from curvlinops.examples.utils import report_nonclose
 
 # make deterministic
@@ -151,7 +151,7 @@ inv_damped_GGN_mat = numpy.linalg.inv(damped_GGN_mat)
 #  Next, let's compute the gradient with :code:`functorch`, using a utility
 #  function from :code:`curvlinops.examples`:
 
-gradient_functorch = functorch_gradient(model, loss_function, params, data)
+gradient_functorch, _ = functorch_gradient_and_loss(model, loss_function, params, data)
 # convert to numpy (vector) format
 gradient_functorch = (
     nn.utils.parameters_to_vector(gradient_functorch).detach().cpu().numpy()

--- a/test/test__torch_base.py
+++ b/test/test__torch_base.py
@@ -5,7 +5,9 @@ from typing import List
 from pytest import raises
 from torch import Tensor, zeros
 
-from curvlinops._torch_base import PyTorchLinearOperator
+from curvlinops._torch_base import CurvatureLinearOperator, PyTorchLinearOperator
+from curvlinops.examples.functorch import functorch_gradient_and_loss
+from curvlinops.utils import allclose_report
 
 
 def test_input_formatting():
@@ -80,3 +82,28 @@ def test_preserve_input_format():
     X = zeros(26, 6)  # matrix in tensor format
     IdX = Id @ X
     assert IdX.allclose(X)
+
+
+def test_gradient_and_loss(case):
+    """Test the gradient and loss computation over a data loader."""
+    model, loss_func, params, data, batch_size_fn = case
+
+    linop = CurvatureLinearOperator(
+        model,
+        loss_func,
+        params,
+        data,
+        # turn off because this would trigger the un-implemented `matmat`
+        check_deterministic=False,
+        batch_size_fn=batch_size_fn,
+    )
+    gradient, loss = linop.gradient_and_loss()
+
+    gradient_functorch, loss_functorch = functorch_gradient_and_loss(
+        model, loss_func, params, data, input_key="x"
+    )
+
+    assert allclose_report(loss, loss_functorch)
+    assert len(gradient) == len(gradient_functorch)
+    for g, g_functorch in zip(gradient, gradient_functorch):
+        assert allclose_report(g, g_functorch)

--- a/test/test__torch_base.py
+++ b/test/test__torch_base.py
@@ -39,44 +39,44 @@ def test_output_formatting():
     in_shape = [(2, 3), (4, 5)]
     out_shape = [(2, 3), (4, 6)]  # NOTE that this will trigger an error
 
-    I = IdentityLinearOperator(in_shape, out_shape)
-    assert I._in_shape_flat == [6, 20]
-    assert I._out_shape_flat == [6, 24]
-    assert I.shape == (30, 26)
+    Id = IdentityLinearOperator(in_shape, out_shape)
+    assert Id._in_shape_flat == [6, 20]
+    assert Id._out_shape_flat == [6, 24]
+    assert Id.shape == (30, 26)
 
     # using valid input vectors/matrices will trigger errors because we
     # initialized the identity with different input/output spaces
     with raises(ValueError):
-        _ = I @ [zeros(2, 3), zeros(4, 5)]  # valid vector in list format
+        _ = Id @ [zeros(2, 3), zeros(4, 5)]  # valid vector in list format
 
     with raises(ValueError):
-        _ = I @ [zeros(2, 3, 6), zeros(4, 5, 6)]  # valid matrix in list format
+        _ = Id @ [zeros(2, 3, 6), zeros(4, 5, 6)]  # valid matrix in list format
 
     with raises(ValueError):
-        _ = I @ zeros(26)  # valid vector in tensor format
+        _ = Id @ zeros(26)  # valid vector in tensor format
 
     with raises(ValueError):
-        _ = I @ zeros(26, 6)  # valid matrix in tensor format
+        _ = Id @ zeros(26, 6)  # valid matrix in tensor format
 
 
 def test_preserve_input_format():
     """Test whether the input format is preserved by matrix multiplication."""
     in_shape = out_shape = [(2, 3), (4, 5)]
-    I = IdentityLinearOperator(in_shape, out_shape)
-    assert I._in_shape_flat == I._out_shape_flat == [6, 20]
+    Id = IdentityLinearOperator(in_shape, out_shape)
+    assert Id._in_shape_flat == Id._out_shape_flat == [6, 20]
 
     X = [zeros(2, 3), zeros(4, 5)]  # vector in tensor list format
-    IX = I @ X
-    assert len(IX) == len(X) and all(Ix.allclose(x) for Ix, x in zip(IX, X))
+    IdX = Id @ X
+    assert len(IdX) == len(X) and all(Idx.allclose(x) for Idx, x in zip(IdX, X))
 
     X = [zeros(2, 3, 6), zeros(4, 5, 6)]  # matrix in tensor list format
-    IX = I @ X
-    assert len(IX) == len(X) and all(Ix.allclose(x) for Ix, x in zip(IX, X))
+    IdX = Id @ X
+    assert len(IdX) == len(X) and all(Idx.allclose(x) for Idx, x in zip(IdX, X))
 
     X = zeros(26)  # vector in tensor format
-    IX = I @ X
-    assert IX.allclose(X)
+    IdX = Id @ X
+    assert IdX.allclose(X)
 
     X = zeros(26, 6)  # matrix in tensor format
-    IX = I @ X
-    assert IX.allclose(X)
+    IdX = Id @ X
+    assert IdX.allclose(X)

--- a/test/test__torch_base.py
+++ b/test/test__torch_base.py
@@ -1,0 +1,82 @@
+"""Tests the linear operator interface in PyTorch."""
+
+from typing import List
+
+from pytest import raises
+from torch import Tensor, zeros
+
+from curvlinops._torch_base import PyTorchLinearOperator
+
+
+def test_input_formatting():
+    """Test format checks of the input to a matrix multiplication."""
+    in_shape = [(2, 3), (4, 5)]
+
+    L = PyTorchLinearOperator(in_shape, in_shape)
+    assert L._in_shape_flat == L._out_shape_flat == [6, 20]
+    assert L.shape == (26, 26)
+
+    # try multiplying with invalid vectors/matrices
+    with raises(ValueError):
+        _ = L @ zeros(25)  # too few numbers
+
+    with raises(ValueError):
+        _ = L @ [zeros(2, 3), zeros(4, 4)]  # wrong shape in second tensor
+
+    with raises(ValueError):
+        _ = L @ [zeros(2, 3, 6), zeros(4, 5, 7)]  # ambiguous number of vectors
+
+
+class IdentityLinearOperator(PyTorchLinearOperator):
+    """Linear operator in PyTorch representing the identity matrix."""
+
+    def _matmat(self, X: List[Tensor]) -> List[Tensor]:
+        return X
+
+
+def test_output_formatting():
+    """Test format checks of the output of a matrix multiplication."""
+    in_shape = [(2, 3), (4, 5)]
+    out_shape = [(2, 3), (4, 6)]  # NOTE that this will trigger an error
+
+    I = IdentityLinearOperator(in_shape, out_shape)
+    assert I._in_shape_flat == [6, 20]
+    assert I._out_shape_flat == [6, 24]
+    assert I.shape == (30, 26)
+
+    # using valid input vectors/matrices will trigger errors because we
+    # initialized the identity with different input/output spaces
+    with raises(ValueError):
+        _ = I @ [zeros(2, 3), zeros(4, 5)]  # valid vector in list format
+
+    with raises(ValueError):
+        _ = I @ [zeros(2, 3, 6), zeros(4, 5, 6)]  # valid matrix in list format
+
+    with raises(ValueError):
+        _ = I @ zeros(26)  # valid vector in tensor format
+
+    with raises(ValueError):
+        _ = I @ zeros(26, 6)  # valid matrix in tensor format
+
+
+def test_preserve_input_format():
+    """Test whether the input format is preserved by matrix multiplication."""
+    in_shape = out_shape = [(2, 3), (4, 5)]
+    I = IdentityLinearOperator(in_shape, out_shape)
+    assert I._in_shape_flat == I._out_shape_flat == [6, 20]
+
+    X = [zeros(2, 3), zeros(4, 5)]  # vector in tensor list format
+    IX = I @ X
+    assert len(IX) == len(X) and all(Ix.allclose(x) for Ix, x in zip(IX, X))
+
+    X = [zeros(2, 3, 6), zeros(4, 5, 6)]  # matrix in tensor list format
+    IX = I @ X
+    assert len(IX) == len(X) and all(Ix.allclose(x) for Ix, x in zip(IX, X))
+
+    X = zeros(26)  # vector in tensor format
+    IX = I @ X
+    assert IX.allclose(X)
+
+    X = zeros(26, 6)  # matrix in tensor format
+    IX = I @ X
+    assert IX.allclose(X)


### PR DESCRIPTION
This PR introduces a class `CurvatureLinearOperator`, which is almost identical to the current base class `_LinearOperator`, but inherits from `PyTorchLinearOperator`.

The next steps will be to (i) migrate each linear operator to inherit from `CurvatureLinearOperator`, rather than `_LinearOperator`, (ii) delete `_LinearOperator`.