### PR TITLE
[FIX] in-place damping bug in `KFACInverseLinearOperator`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed/Removed
 
+- Bug in `KFACInverseLinearOperator` where the damping was repeatedly (for every
+  matrix-vector product) added to the eigenvalues corresponding to the bias parameters
+  when `use_exact_damping=True` and `KFACLinearOperator._separate_weight_and_bias=True`
+  ([PR](https://github.com/f-dangel/curvlinops/pull/156))
+
 ### Internal
 
 ## [2.0.1] - 2024-10-25

--- a/curvlinops/inverse.py
+++ b/curvlinops/inverse.py
@@ -593,7 +593,7 @@ class KFACInverseLinearOperator(_InverseLinearOperator):
                         M_torch[pos], aaT_eigvecs, "m i j, k j -> m i k"
                     )
                 else:
-                    M_torch[pos].div_(ggT_eigvals.add_(self._damping))
+                    M_torch[pos].div_(ggT_eigvals.add(self._damping))
                 M_torch[pos] = einsum(
                     ggT_eigvecs, M_torch[pos], "i j, m j ... -> m i ..."
                 )

--- a/test/test_inverse.py
+++ b/test/test_inverse.py
@@ -521,7 +521,11 @@ def test_KFAC_inverse_exactly_damped_matmat(
         assert len(inv_KFAC._inverse_gradient_covariances) == 0
 
 
+@mark.parametrize(
+    "use_exact_damping", [True, False], ids=["exact_damping", "heuristic_damping"]
+)
 def test_KFAC_inverse_damped_torch_matmat(
+    use_exact_damping: bool,
     case: Tuple[
         Module,
         Union[MSELoss, CrossEntropyLoss],
@@ -554,7 +558,11 @@ def test_KFAC_inverse_damped_torch_matmat(
         check_deterministic=False,
     )
     KFAC.dtype = float64
-    inv_KFAC = KFACInverseLinearOperator(KFAC, damping=(delta, delta))
+    kwargs = {
+        "use_exact_damping": use_exact_damping,
+        "use_heuristic_damping": not use_exact_damping,
+    }
+    inv_KFAC = KFACInverseLinearOperator(KFAC, damping=delta, **kwargs)
     device = KFAC._device
 
     num_vectors = 2
@@ -584,7 +592,11 @@ def test_KFAC_inverse_damped_torch_matmat(
     report_nonclose(inv_KFAC_X, kfac_x_numpy)
 
 
+@mark.parametrize(
+    "use_exact_damping", [True, False], ids=["exact_damping", "heuristic_damping"]
+)
 def test_KFAC_inverse_damped_torch_matvec(
+    use_exact_damping: bool,
     case: Tuple[
         Module,
         Union[MSELoss, CrossEntropyLoss],
@@ -617,7 +629,11 @@ def test_KFAC_inverse_damped_torch_matvec(
         check_deterministic=False,
     )
     KFAC.dtype = float64
-    inv_KFAC = KFACInverseLinearOperator(KFAC, damping=(delta, delta))
+    kwargs = {
+        "use_exact_damping": use_exact_damping,
+        "use_heuristic_damping": not use_exact_damping,
+    }
+    inv_KFAC = KFACInverseLinearOperator(KFAC, damping=delta, **kwargs)
     device = KFAC._device
 
     x = torch.rand(KFAC.shape[1], dtype=dtype, device=device)


### PR DESCRIPTION
When `use_exact_damping=True` and `KFACLinearOperator._separate_weight_and_bias=True`, the damping will be repeatedly added to the eigenvalues corresponding to the bias parameters with every matrix-vector product.