### PR TITLE
Stop overriding `model_func` state dictionary when loading state dicts of K-FAC or K-FAC inverse

### DIFF
--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -44,6 +44,7 @@ from curvlinops.kfac_utils import (
     extract_patches,
     loss_hessian_matrix_sqrt,
 )
+from curvlinops.utils import do_statedicts_match
 
 
 class MetaEnum(EnumMeta):
@@ -952,7 +953,14 @@ class KFACLinearOperator(CurvatureLinearOperator):
             ValueError: If the loss function does not match the state dict.
             ValueError: If the loss function reduction does not match the state dict.
         """
-        self._model_func.load_state_dict(state_dict["model_func_state_dict"])
+        # Do not overwrite _model_func, but make sure the parameters match:
+        if not do_statedicts_match(state_dict, self._model_func.state_dict()):
+            raise ValueError(
+                "Passed `state_dict` does not match the `state_dict()` of the:
+                "referenced `model_func`. Update the `state_dict` of the `model_func` "
+                "passed to this class first."
+            )
+
         # Verify that the loss function and its reduction match the state dict
         loss_func_type = {
             "MSELoss": MSELoss,

--- a/curvlinops/utils.py
+++ b/curvlinops/utils.py
@@ -1,6 +1,6 @@
 """General utility functions."""
 
-from typing import List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 from numpy import cumsum
 from torch import Tensor
@@ -115,3 +115,33 @@ def assert_divisible_by(num: int, divisor: int, name: str):
     """
     if num % divisor != 0:
         raise ValueError(f"{name} ({num}) must be divisible by {divisor}.")
+
+
+def do_statedicts_match(statedict1: dict[str, Any], statedict2: dict[str, Any]) -> bool:
+    """Compare two state dictionaries for equality. Each statedict can be a nested
+    dictionary from string keys to Tensors, floats, ints or another statedict.
+
+    Args:
+        statedict1: First state dictionary to compare.
+        statedict2: Second state dictionary to compare.
+
+    Returns:
+        bool: True if the state dictionaries match exactly, False otherwise.
+
+    Note:
+        Performs deep comparison of nested dictionaries and tensors. For tensors,
+        checks element-wise equality.
+    """
+    if len(statedict1) != len(statedict2):
+        return False
+    for key in statedict1.keys():
+        if isinstance(statedict1[key], dict):
+            if not do_statedicts_match(statedict1[key], statedict2[key]):
+                return False
+        elif isinstance(statedict1, Tensor):
+            if not (statedict1[key] == statedict2[key]).all():
+                return False
+        else:
+            if statedict1[key] != statedict2[key]:
+                return False
+    return True


### PR DESCRIPTION
Currently, when calling `.load_state_dict(state_dict)` on a `KFACLinearOperator` or `KFACInverseLinearOperator` object initialised with some `model_func`, this will override the state dictionary of the `model_func`. This might lead to unexpected behaviour, wherein:

**1)** _(minor)_ The user suddenly ends up with parameters of their model overwritten:
```python
model = ...
kfac = KFACLinearOperator(model_func=model, ...)
kfac.load_state_dict(torch.load("kfac_state_dict.torch"))
# Parameters of `model` have been silently overwritten
```
**2)** _(major)_ The references that the user was using no longer point to the same parameters:
```python
feature_extractor = ConvNet(...)  # A PyTorch module
model = nn.Sequential(
    feature_extractor,
    nn.Linear(...)
)
# model[0].parameters() and feature_extractor.parameters() are pointers to the same tensors.

kfac = KFACLinearOperator(model_func=model, ...)
kfac.load_state_dict(torch.load("kfac_state_dict.torch"))
# model[0].parameters() and feature_extractor.parameters() are now pointers to different tensors.
```

**2)** is an issue that we've already unexpectedly run into.

---

Proposed solution: Do not overwrite the `state_dict` of the model passed to `KFACLinearOperator` when loading the `state_dict` into a linear operator. Instead, verify that the state_dicts are the same, and throw an error if they're not (it should be up to the user to make sure the `state_dict` of the model matches first). Hence, `self._model_func` is still guaranteed to, numerically, be as expected, but we avoid keeping a new copy of `state_dict` in memory with different pointers.