### PR TITLE
[DOC] Note operators that are not compiler-friendly

### DIFF
--- a/curvlinops/inverse.py
+++ b/curvlinops/inverse.py
@@ -54,6 +54,12 @@ class CGInverseLinearOperator(_InversePyTorchLinearOperator):
 
     Note:
         Internally, this operator uses GPyTorch's implementation of CG.
+
+    .. note::
+        This operator is not compiler-friendly (:func:`torch.compile`). The underlying
+        ``linear_cg`` routine uses data-dependent control flow (convergence checks
+        on tensor values via ``aten.equal`` and Python ``if`` on tensors), which
+        causes graph breaks during tracing.
     """
 
     def __init__(self, A: PyTorchLinearOperator, **cg_hyperparameters):
@@ -107,6 +113,11 @@ class LSMRInverseLinearOperator(_InversePyTorchLinearOperator):
         Internally, this operator uses SciPy's CPU implementation of LSMR as PyTorch
         currently does not offer an LSMR interface that purely relies on matrix-vector
         products.
+
+    .. note::
+        This operator is not compiler-friendly (:func:`torch.compile`). The matrix-vector
+        product converts tensors to NumPy and calls SciPy's ``lsmr``; these non-Torch
+        operations cannot be traced and cause graph breaks.
     """
 
     def __init__(self, A: PyTorchLinearOperator, **lsmr_hyperparameters):
@@ -182,6 +193,13 @@ class NeumannInverseLinearOperator(_InversePyTorchLinearOperator):
     .. warning::
         The Neumann series can converge slowly.
         Use :py:class:`curvlinops.CGInverLinearOperator` for better accuracy.
+
+    .. note::
+        With the default ``check_nan=True``, this operator is not compiler-friendly
+        (:func:`torch.compile`): the per-iteration ``isnan`` check introduces
+        data-dependent branching that causes graph breaks. Passing ``check_nan=False``
+        makes the operator compiler-friendly (the truncated series itself uses only
+        traceable PyTorch ops).
     """
 
     def __init__(

--- a/curvlinops/submatrix.py
+++ b/curvlinops/submatrix.py
@@ -8,7 +8,14 @@ from curvlinops._torch_base import PyTorchLinearOperator
 
 
 class SubmatrixLinearOperator(PyTorchLinearOperator):
-    """Class for sub-matrices of linear operators."""
+    """Class for sub-matrices of linear operators.
+
+    .. note::
+        This operator is not compiler-friendly (:func:`torch.compile`). Its matrix-vector
+        product dispatches through the wrapped operator's ``__matmul__``, and Dynamo
+        cannot proxy a user-defined linear operator as an argument, which causes graph
+        breaks.
+    """
 
     def __init__(
         self, A: PyTorchLinearOperator, row_idxs: list[int], col_idxs: list[int]


### PR DESCRIPTION
## Summary
- Add `.. note::` blocks to the class docstrings of `CGInverseLinearOperator`, `LSMRInverseLinearOperator`, `NeumannInverseLinearOperator`, and `SubmatrixLinearOperator` stating they are not compatible with `torch.compile`.
- Each note names the observed root cause:
  - **CG**: `linear_cg`'s data-dependent control flow (`aten.equal`, Python `if` on tensors).
  - **LSMR**: tensors → NumPy → SciPy's `lsmr` (non-Torch ops cannot be traced).
  - **Neumann**: `isnan` check under `check_nan=True`; setting `check_nan=False` restores compiler-friendliness.
  - **Submatrix**: dispatches through the wrapped operator's `__matmul__`, and Dynamo cannot proxy a user-defined operator.

## Test plan
- [ ] No code changes; docs only. Build RTD docs locally to confirm rendering of `.. note::` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)