### PR TITLE
Support layer-wise damping for KFAC/EKFAC, which might be useful for adaptive damping and faster convergence.

### DIFF
--- a/curvlinops/ekfac.py
+++ b/curvlinops/ekfac.py
@@ -1,5 +1,7 @@
 """Contains LinearOperator implementation of EKFAC approximation of the Fisher/GGN."""
 
+from collections.abc import Sequence
+
 from curvlinops._torch_base import _ChainPyTorchLinearOperator
 from curvlinops.blockdiagonal import BlockDiagonalLinearOperator
 from curvlinops.computers._base import ParamGroup
@@ -66,21 +68,26 @@ class EKFACLinearOperator(KFACLinearOperator):
         # EKFAC in the canonical basis
         return BlockDiagonalLinearOperator(blocks), mapping
 
-    def inverse(self, damping: float = 0.0) -> _ChainPyTorchLinearOperator:
+    def inverse(
+        self, damping: float | Sequence[float] = 0.0
+    ) -> _ChainPyTorchLinearOperator:
         """Return the inverse of the EKFAC approximation.
 
         Inverts each eigendecomposed block of the canonical operator
         and returns the result in parameter space.
 
         Args:
-            damping: Damping term added to eigenvalues before inversion.
-                Default: ``0.0``.
+            damping: Damping value applied to each canonical block. If it is a scalar,
+                the same value is used for all blocks. If it is a sequence, it must
+                contain one damping value per canonical block. Default: ``0.0``.
 
         Returns:
             Inverse of the EKFAC approximation as a linear operator.
         """
         P, K, PT = self
+        damping_per_block = self._broadcast_damping(damping, len(K))
         K_inv = BlockDiagonalLinearOperator([
-            block.inverse(damping=damping) for block in K
+            block.inverse(damping=block_damping)
+            for block, block_damping in zip(K, damping_per_block)
         ])
         return _ChainPyTorchLinearOperator(P, K_inv, PT)

--- a/curvlinops/examples/__init__.py
+++ b/curvlinops/examples/__init__.py
@@ -1,8 +1,10 @@
-"""Contains functionality for examples in the documentation."""
+"""Utilities used throughout the documentation examples."""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, MutableMapping
+from dataclasses import dataclass
+from math import sqrt
 
 from torch import (
     Tensor,
@@ -59,6 +61,142 @@ def gradient_and_loss(
         check_deterministic=False,
     )
     return mixin._gradient_and_loss()
+
+
+def gradient_l2_norm(gradient: Iterable[Tensor | None]) -> Tensor:
+    """Compute the Euclidean norm of a gradient stored as tensors.
+
+    Args:
+        gradient: Iterable containing gradient tensors. Entries can be ``None`` and
+            will be ignored.
+
+    Returns:
+        Euclidean norm of the concatenated gradient.
+
+    Raises:
+        ValueError: If no gradient tensor is provided.
+    """
+    sq_norm = None
+    for g in gradient:
+        if g is None:
+            continue
+        sq_norm = g.pow(2).sum() if sq_norm is None else sq_norm + g.pow(2).sum()
+
+    if sq_norm is None:
+        raise ValueError("Expected at least one gradient tensor.")
+
+    return sq_norm.sqrt()
+
+
+def _check_damping_hyperparameters(damping_scale: float, min_damping: float):
+    """Validate the scalar hyperparameters for gradient-norm damping.
+
+    Args:
+        damping_scale: Non-negative scale factor in the damping rule.
+        min_damping: Non-negative lower bound on the damping value.
+
+    Raises:
+        ValueError: If ``damping_scale`` or ``min_damping`` is negative.
+    """
+    if damping_scale < 0.0:
+        raise ValueError(f"Expected damping_scale >= 0. Got {damping_scale = }.")
+    if min_damping < 0.0:
+        raise ValueError(f"Expected min_damping >= 0. Got {min_damping = }.")
+
+
+def gradient_norm_damping(
+    gradient: Iterable[Tensor | None], damping_scale: float, min_damping: float = 0.0
+) -> float:
+    r"""Compute adaptive damping from gradient tensors.
+
+    This damping rule appears in
+    `Mishchenko, 2023 <https://doi.org/10.1137/22M1488752>`_ as a cheap
+    Levenberg-Marquardt interpretation of cubic regularization.
+
+    Args:
+        gradient: Iterable containing gradient tensors. Entries can be ``None`` and
+            will be ignored.
+        damping_scale: Non-negative constant ``c`` in the rule
+            ``sqrt(c * ||g||_2)``.
+        min_damping: Non-negative lower bound on the damping value.
+            Default: ``0.0``.
+
+    Returns:
+        Adaptive damping value as a Python ``float``.
+
+    Example:
+        If ``gradients`` is a list of tensors with the same structure as the
+        model parameters, the damping is simply
+
+        ``gradient_norm_damping(gradients, damping_scale=1e-1, min_damping=1e-4)``.
+    """
+    _check_damping_hyperparameters(damping_scale, min_damping)
+    return max(min_damping, sqrt(damping_scale * gradient_l2_norm(gradient).item()))
+
+
+@dataclass(frozen=True)
+class GradientNormDamping:
+    r"""Callable gradient-norm damping policy.
+
+    This is a small convenience wrapper around :func:`gradient_norm_damping`.
+    It is useful when the hyperparameters are fixed for an entire run:
+
+    .. code-block:: python
+
+        damping_rule = GradientNormDamping(damping_scale=1e-1, min_damping=1e-4)
+        damping = damping_rule(gradients)
+
+    If you need one damping value per KFAC/EKFAC block, use :meth:`per_block`
+    with one gradient collection per block.
+
+    The policy computes
+
+    .. math::
+
+        \lambda = \max(\lambda_{\min}, \sqrt{c \lVert g \rVert_2})
+
+    from a collection of gradient tensors.
+
+    Attributes:
+        damping_scale: Non-negative constant ``c`` in the damping rule.
+        min_damping: Non-negative lower bound on the damping value.
+    """
+
+    damping_scale: float
+    min_damping: float = 0.0
+
+    def __post_init__(self):
+        """Validate the damping policy hyperparameters."""
+        _check_damping_hyperparameters(self.damping_scale, self.min_damping)
+
+    def __call__(self, gradient: Iterable[Tensor | None]) -> float:
+        """Evaluate the damping rule on a gradient collection.
+
+        Args:
+            gradient: Iterable containing gradient tensors. Entries can be ``None`` and
+                will be ignored.
+
+        Returns:
+            Damping value as a Python ``float``.
+        """
+        return gradient_norm_damping(gradient, self.damping_scale, self.min_damping)
+
+    def per_block(
+        self, block_gradients: Iterable[Iterable[Tensor | None]]
+    ) -> tuple[float, ...]:
+        """Evaluate the damping rule independently for each block.
+
+        This is useful with APIs that accept one damping value per canonical block,
+        such as ``KFACLinearOperator.inverse`` and ``EKFACLinearOperator.inverse``.
+
+        Args:
+            block_gradients: Iterable where each entry contains the gradient tensors
+                associated with one block.
+
+        Returns:
+            Tuple containing one damping value per block.
+        """
+        return tuple(self(gradient) for gradient in block_gradients)
 
 
 class TensorLinearOperator(PyTorchLinearOperator):

--- a/curvlinops/kfac.py
+++ b/curvlinops/kfac.py
@@ -16,7 +16,7 @@ and generalized to all linear layers with weight sharing in
   Kronecker-Factored Approximate Curvature for Modern Neural Network Architectures (NeurIPS).
 """
 
-from collections.abc import Callable, Iterable, MutableMapping
+from collections.abc import Callable, Iterable, MutableMapping, Sequence
 
 from torch import Tensor
 from torch.nn import (
@@ -308,9 +308,37 @@ class KFACLinearOperator(_ChainPyTorchLinearOperator):
         _, K, _ = self
         return K.frobenius_norm()
 
+    @staticmethod
+    def _broadcast_damping(
+        damping: float | Sequence[float], num_blocks: int
+    ) -> tuple[float, ...]:
+        """Return one damping value per canonical block.
+
+        Args:
+            damping: Scalar damping or one damping value per canonical block.
+            num_blocks: Number of canonical blocks.
+
+        Returns:
+            Tuple containing one damping value per canonical block.
+
+        Raises:
+            ValueError: If ``damping`` is a sequence whose length does not match
+                ``num_blocks``.
+        """
+        if isinstance(damping, Sequence):
+            if len(damping) != num_blocks:
+                raise ValueError(
+                    "Expected damping to be a scalar or a sequence containing one "
+                    f"scalar per canonical block. Got {len(damping)} values for "
+                    f"{num_blocks} blocks."
+                )
+            return tuple(damping)
+
+        return num_blocks * (damping,)
+
     def inverse(
         self,
-        damping: float = 0.0,
+        damping: float | Sequence[float] = 0.0,
         use_heuristic_damping: bool = False,
         min_damping: float = 1e-8,
         use_exact_damping: bool = False,
@@ -322,7 +350,9 @@ class KFACLinearOperator(_ChainPyTorchLinearOperator):
         and returns the result in parameter space.
 
         Args:
-            damping: Damping value applied to all Kronecker factors. Default: ``0.0``.
+            damping: Damping value applied to each canonical block. If it is a scalar,
+                the same value is used for all blocks. If it is a sequence, it must
+                contain one damping value per canonical block. Default: ``0.0``.
             use_heuristic_damping: Whether to use a heuristic damping strategy by
                 `Martens and Grosse, 2015 <https://arxiv.org/abs/1503.05671>`_
                 (Section 6.3). Only supported for one or two factors.
@@ -337,14 +367,15 @@ class KFACLinearOperator(_ChainPyTorchLinearOperator):
             Inverse of the KFAC approximation as a linear operator ``P @ K^-1 @ PT``.
         """
         P, K, PT = self
+        damping_per_block = self._broadcast_damping(damping, len(K))
         K_inv = BlockDiagonalLinearOperator([
             block.inverse(
-                damping=damping,
+                damping=block_damping,
                 use_heuristic_damping=use_heuristic_damping,
                 min_damping=min_damping,
                 use_exact_damping=use_exact_damping,
                 retry_double_precision=retry_double_precision,
             )
-            for block in K
+            for block, block_damping in zip(K, damping_per_block)
         ])
         return _ChainPyTorchLinearOperator(P, K_inv, PT)

--- a/test/examples/test___init__.py
+++ b/test/examples/test___init__.py
@@ -1,10 +1,18 @@
 """Tests for ``curvlinops.examples``."""
 
 from collections.abc import Callable, Iterable, MutableMapping
+from math import sqrt
 
+import pytest
 from torch import Tensor, float64
+from torch import tensor as torch_tensor
 
-from curvlinops.examples import gradient_and_loss
+from curvlinops.examples import (
+    GradientNormDamping,
+    gradient_and_loss,
+    gradient_l2_norm,
+    gradient_norm_damping,
+)
 from curvlinops.examples.functorch import functorch_gradient_and_loss
 from curvlinops.utils import allclose_report
 from test.utils import change_dtype
@@ -38,3 +46,110 @@ def test_gradient_and_loss(
     assert len(gradient) == len(gradient_functorch)
     for g, g_functorch in zip(gradient, gradient_functorch):
         assert allclose_report(g, g_functorch)
+
+
+def test_gradient_l2_norm():
+    """Test the Euclidean norm helper for gradient tensor collections."""
+    gradient = [
+        torch_tensor([[3.0, 4.0]]),
+        None,
+        torch_tensor([12.0]),
+    ]
+
+    assert allclose_report(gradient_l2_norm(gradient), torch_tensor(13.0))
+
+
+def test_gradient_l2_norm_raises_on_missing_gradient():
+    """The norm helper should reject collections without gradient tensors."""
+    with pytest.raises(ValueError, match="Expected at least one gradient tensor."):
+        gradient_l2_norm([None, None])
+
+
+def test_gradient_norm_damping():
+    """Test the explicit gradient-norm damping helper."""
+    gradient = [torch_tensor([3.0, 4.0])]
+
+    assert gradient_norm_damping(gradient, damping_scale=0.8, min_damping=2.5) == 2.5
+    assert gradient_norm_damping(
+        gradient, damping_scale=1.8, min_damping=0.5
+    ) == pytest.approx(sqrt(1.8 * 5.0))
+
+
+def test_gradient_norm_damping_ignores_none_entries():
+    """Gradient-norm damping should use the norm over the non-``None`` entries."""
+    gradient = [
+        torch_tensor([[3.0, 4.0]]),
+        None,
+        torch_tensor([12.0]),
+    ]
+
+    assert gradient_norm_damping(
+        gradient, damping_scale=1.3, min_damping=0.0
+    ) == pytest.approx(sqrt(1.3 * 13.0))
+
+
+def test_gradient_norm_damping_on_full_dataset_gradient(
+    case: tuple[
+        Callable[[Tensor], Tensor],
+        Callable[[Tensor, Tensor], Tensor],
+        dict[str, Tensor],
+        Iterable[tuple[Tensor | MutableMapping, Tensor]],
+        Callable[[MutableMapping], int] | None,
+    ],
+):
+    """Gradient-norm damping should match the rule on a real autograd gradient."""
+    model, loss_func, params, data, batch_size_fn = change_dtype(case, float64)
+    gradient, _ = gradient_and_loss(
+        model, loss_func, params, data, batch_size_fn=batch_size_fn
+    )
+
+    damping_scale = 0.7
+    min_damping = 1e-4
+    expected = max(min_damping, sqrt(damping_scale * gradient_l2_norm(gradient).item()))
+
+    assert gradient_norm_damping(gradient, damping_scale, min_damping) == pytest.approx(
+        expected
+    )
+
+
+@pytest.mark.parametrize("damping_scale,min_damping", [(-1.0, 0.0), (1.0, -1.0)])
+def test_gradient_norm_damping_raises_on_negative_inputs(
+    damping_scale: float, min_damping: float
+):
+    """Gradient-norm damping should reject negative hyperparameters."""
+    with pytest.raises(ValueError):
+        gradient_norm_damping([torch_tensor([1.0])], damping_scale, min_damping)
+
+
+def test_gradient_norm_damping_raises_on_missing_gradient():
+    """Gradient-norm damping should reject collections without gradient tensors."""
+    with pytest.raises(ValueError, match="Expected at least one gradient tensor."):
+        gradient_norm_damping([None, None], damping_scale=1.0)
+
+
+def test_gradient_norm_damping_policy():
+    """The callable policy should evaluate the gradient-norm rule."""
+    policy = GradientNormDamping(damping_scale=1.8, min_damping=0.5)
+    gradient = [torch_tensor([3.0, 4.0])]
+
+    assert policy(gradient) == pytest.approx(sqrt(1.8 * 5.0))
+
+
+def test_gradient_norm_damping_policy_per_block():
+    """The callable policy should produce one damping value per block."""
+    policy = GradientNormDamping(damping_scale=0.8, min_damping=0.5)
+    block_gradients = (
+        [torch_tensor([3.0, 4.0])],
+        [torch_tensor([0.0]), torch_tensor([0.0])],
+    )
+
+    assert policy.per_block(block_gradients) == pytest.approx((2.0, 0.5))
+
+
+@pytest.mark.parametrize("damping_scale,min_damping", [(-1.0, 0.0), (1.0, -1.0)])
+def test_gradient_norm_damping_policy_raises_on_negative_inputs(
+    damping_scale: float, min_damping: float
+):
+    """The callable policy should reject negative hyperparameters."""
+    with pytest.raises(ValueError):
+        GradientNormDamping(damping_scale=damping_scale, min_damping=min_damping)

--- a/test/test_ekfac.py
+++ b/test/test_ekfac.py
@@ -19,6 +19,7 @@ from torch.nn import (
 from curvlinops import EFLinearOperator, GGNLinearOperator
 from curvlinops.computers.ekfac_hooks import HooksEKFACComputer
 from curvlinops.ekfac import EKFACLinearOperator
+from curvlinops.examples import TensorLinearOperator
 from curvlinops.kfac_utils import FisherType, KFACType
 from curvlinops.utils import allclose_report
 from test.cases import DEVICES, DEVICES_IDS
@@ -730,6 +731,143 @@ def test_EKFAC_inverse_exactly_damped_matmat(
 
     compare_consecutive_matmats(inv_EKFAC)
     compare_matmat(inv_EKFAC, inv_EKFAC_naive)
+
+
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
+def test_EKFAC_inverse_exactly_damped_matmat_per_block(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    separate_weight_and_bias: bool,
+    delta: float = 1e-2,
+):
+    """Test matrix-matrix multiplication by a per-block damped EKFAC inverse."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    EKFAC = EKFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+
+    _, K, _ = EKFAC
+    damping = tuple(delta * (idx + 1) for idx in range(len(K)))
+    inv_EKFAC = EKFAC.inverse(damping=damping)
+
+    # Materialize each block, add its individual damping, then reassemble.
+    for idx, (block, damping_i) in enumerate(zip(K, damping)):
+        damped_block = block @ eye_like(block) + damping_i * eye_like(block)
+        K[idx] = TensorLinearOperator(damped_block)
+    inv_EKFAC_naive = inv(EKFAC @ eye_like(EKFAC))
+
+    compare_consecutive_matmats(inv_EKFAC)
+    compare_matmat(inv_EKFAC, inv_EKFAC_naive)
+
+
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
+def test_EKFAC_inverse_uniform_per_block_damping_matches_scalar(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    separate_weight_and_bias: bool,
+    delta: float = 1e-2,
+):
+    """Uniform per-block damping should match the scalar EKFAC inverse path."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    EKFAC = EKFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+
+    uniform_damping = (delta,) * len(EKFAC[1])
+    inv_EKFAC_scalar = EKFAC.inverse(damping=delta)
+    inv_EKFAC_sequence = EKFAC.inverse(damping=uniform_damping)
+
+    compare_consecutive_matmats(inv_EKFAC_sequence)
+    compare_matmat(inv_EKFAC_scalar, inv_EKFAC_sequence)
+
+
+def test_EKFAC_inverse_single_block_sequence_matches_scalar(
+    single_layer_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    delta: float = 1e-2,
+):
+    """A length-1 damping sequence should work for single-block EKFAC operators."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        single_layer_case, float64
+    )
+
+    EKFAC = EKFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        separate_weight_and_bias=False,
+    )
+
+    assert len(EKFAC[1]) == 1
+
+    inv_EKFAC_scalar = EKFAC.inverse(damping=delta)
+    inv_EKFAC_sequence = EKFAC.inverse(damping=(delta,))
+
+    compare_consecutive_matmats(inv_EKFAC_sequence)
+    compare_matmat(inv_EKFAC_scalar, inv_EKFAC_sequence)
+
+
+def test_EKFAC_inverse_raises_on_bad_damping_length(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+):
+    """Per-block damping should require one value per canonical block."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    EKFAC = EKFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+    )
+
+    bad_lengths = {0, len(EKFAC[1]) - 1, len(EKFAC[1]) + 1}
+    bad_lengths.discard(len(EKFAC[1]))
+
+    for num_damping in sorted(bad_lengths):
+        with raises(ValueError, match="one scalar per canonical block"):
+            EKFAC.inverse(damping=(1e-2,) * num_damping)
 
 
 def test_ekfac_make_fx_flatten_different_batch_sizes():

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -31,6 +31,7 @@ from torch.nn import (
 
 from curvlinops import EFLinearOperator, GGNLinearOperator
 from curvlinops.computers.kfac_hooks import HooksKFACComputer
+from curvlinops.examples import TensorLinearOperator
 from curvlinops.kfac import KFACLinearOperator
 from curvlinops.kfac_utils import FisherType, KFACType
 from curvlinops.utils import allclose_report
@@ -1183,6 +1184,148 @@ def test_KFAC_inverse_damped_matmat(
     compare_matmat(inv_KFAC, inv_KFAC_naive)
 
 
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
+def test_KFAC_inverse_damped_matmat_per_block(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    separate_weight_and_bias: bool,
+    delta: float = 1e-2,
+):
+    """Test matrix-matrix multiplication by a per-block damped KFAC inverse."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    KFAC = KFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+
+    _, K, _ = KFAC
+    damping = tuple(delta * (idx + 1) for idx in range(len(K)))
+    inv_KFAC = KFAC.inverse(damping=damping)
+
+    # Manually add per-block damping to each Kronecker factor, materialize, invert.
+    for block, damping_i in zip(K, damping):
+        for idx in range(len(block)):
+            # NOTE Needs out-of-place addition because some factors correspond to
+            # the same tensors that would otherwise be damped multiple times.
+            block[idx] = block[idx] + damping_i * eye_like(block[idx])
+    inv_KFAC_naive = inv(KFAC @ eye_like(KFAC))
+
+    compare_consecutive_matmats(inv_KFAC)
+    compare_matmat(inv_KFAC, inv_KFAC_naive)
+
+
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
+def test_KFAC_inverse_uniform_per_block_damping_matches_scalar(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    separate_weight_and_bias: bool,
+    delta: float = 1e-2,
+):
+    """Uniform per-block damping should match the scalar damping path."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    KFAC = KFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+
+    uniform_damping = (delta,) * len(KFAC[1])
+    inv_KFAC_scalar = KFAC.inverse(damping=delta)
+    inv_KFAC_sequence = KFAC.inverse(damping=uniform_damping)
+
+    compare_consecutive_matmats(inv_KFAC_sequence)
+    compare_matmat(inv_KFAC_scalar, inv_KFAC_sequence)
+
+
+def test_KFAC_inverse_single_block_sequence_matches_scalar(
+    single_layer_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    delta: float = 1e-2,
+):
+    """A length-1 damping sequence should work for single-block KFAC operators."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        single_layer_case, float64
+    )
+
+    KFAC = KFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        separate_weight_and_bias=False,
+    )
+
+    assert len(KFAC[1]) == 1
+
+    inv_KFAC_scalar = KFAC.inverse(damping=delta)
+    inv_KFAC_sequence = KFAC.inverse(damping=(delta,))
+
+    compare_consecutive_matmats(inv_KFAC_sequence)
+    compare_matmat(inv_KFAC_scalar, inv_KFAC_sequence)
+
+
+def test_KFAC_inverse_raises_on_bad_damping_length(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+):
+    """Per-block damping should require one value per canonical block."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    KFAC = KFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+    )
+
+    bad_lengths = {0, len(KFAC[1]) - 1, len(KFAC[1]) + 1}
+    bad_lengths.discard(len(KFAC[1]))
+
+    for num_damping in sorted(bad_lengths):
+        with raises(ValueError, match="one scalar per canonical block"):
+            KFAC.inverse(damping=(1e-2,) * num_damping)
+
+
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
 def test_KFAC_inverse_heuristically_damped_matmat(
     case: tuple[
         Module,
@@ -1190,6 +1333,7 @@ def test_KFAC_inverse_heuristically_damped_matmat(
         dict[str, Tensor],
         Iterable[tuple[Tensor, Tensor]],
     ],
+    separate_weight_and_bias: bool,
     delta: float = 1e-2,
 ):
     """Test matrix-matrix multiplication by a heuristically damped KFAC inverse."""
@@ -1203,6 +1347,7 @@ def test_KFAC_inverse_heuristically_damped_matmat(
         data,
         batch_size_fn=batch_size_fn,
         check_deterministic=False,
+        separate_weight_and_bias=separate_weight_and_bias,
     )
 
     inv_KFAC = KFAC.inverse(
@@ -1229,6 +1374,106 @@ def test_KFAC_inverse_heuristically_damped_matmat(
         else:
             block[0] = block[0] + delta * eye_like(block[0])
 
+    inv_KFAC_naive = inv(KFAC @ eye_like(KFAC))
+
+    compare_consecutive_matmats(inv_KFAC)
+    compare_matmat(inv_KFAC, inv_KFAC_naive)
+
+
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
+def test_KFAC_inverse_heuristically_damped_matmat_per_block(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    separate_weight_and_bias: bool,
+    delta: float = 1e-2,
+):
+    """Per-block damping should also work with heuristic KFAC damping."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    KFAC = KFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        check_deterministic=False,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+
+    _, K, _ = KFAC
+    damping = tuple(delta * (idx + 1) for idx in range(len(K)))
+    inv_KFAC = KFAC.inverse(
+        damping=damping,
+        use_heuristic_damping=True,
+        min_damping=KFAC_MIN_DAMPING,
+    )
+
+    # Manually add heuristic damping to each Kronecker factor blockwise.
+    for block, damping_i in zip(K, damping):
+        if len(block) == 2:
+            S1, S2 = block[0], block[1]  # ggT, aaT
+            mean_eig1, mean_eig2 = S1.diag().mean(), S2.diag().mean()
+            if mean_eig1 > 0 and mean_eig2 >= 0:
+                sqrt_eig_mean_ratio = (mean_eig2 / mean_eig1).sqrt()
+                sqrt_damping = sqrt(damping_i)
+                damping1 = max(sqrt_damping / sqrt_eig_mean_ratio, KFAC_MIN_DAMPING)
+                damping2 = max(sqrt_damping * sqrt_eig_mean_ratio, KFAC_MIN_DAMPING)
+            else:
+                damping1, damping2 = damping_i, damping_i
+            block[0] = S1 + damping1 * eye_like(S1)
+            block[1] = S2 + damping2 * eye_like(S2)
+        else:
+            block[0] = block[0] + damping_i * eye_like(block[0])
+
+    inv_KFAC_naive = inv(KFAC @ eye_like(KFAC))
+
+    compare_consecutive_matmats(inv_KFAC)
+    compare_matmat(inv_KFAC, inv_KFAC_naive)
+
+
+@mark.parametrize(
+    "separate_weight_and_bias", [True, False], ids=["separate_bias", "joint_bias"]
+)
+def test_KFAC_inverse_exactly_damped_matmat_per_block(
+    kfac_exact_case: tuple[
+        Module,
+        MSELoss,
+        dict[str, Tensor],
+        Iterable[tuple[Tensor, Tensor]],
+    ],
+    separate_weight_and_bias: bool,
+    delta: float = 1e-2,
+):
+    """Per-block exact damping should match a dense blockwise reference."""
+    model_func, loss_func, params, data, batch_size_fn = change_dtype(
+        kfac_exact_case, float64
+    )
+
+    KFAC = KFACLinearOperator(
+        model_func,
+        loss_func,
+        params,
+        data,
+        batch_size_fn=batch_size_fn,
+        separate_weight_and_bias=separate_weight_and_bias,
+    )
+
+    _, K, _ = KFAC
+    damping = tuple(delta * (idx + 1) for idx in range(len(K)))
+    inv_KFAC = KFAC.inverse(damping=damping, use_exact_damping=True)
+
+    # Materialize each block, add its individual exact damping, then reassemble.
+    for idx, (block, damping_i) in enumerate(zip(K, damping)):
+        damped_block = block @ eye_like(block) + damping_i * eye_like(block)
+        K[idx] = TensorLinearOperator(damped_block)
     inv_KFAC_naive = inv(KFAC @ eye_like(KFAC))
 
     compare_consecutive_matmats(inv_KFAC)


### PR DESCRIPTION
Inspired by the paper: https://arxiv.org/pdf/2112.02089, a regularized Newton Method, and can be used for KFAC/EKFAC
The idea is for each layer $i$, the damping is

$$
\lambda_i = \max(\lambda_{\min}, \sqrt{c \lVert g_i \rVert_2}),
$$

A simple use case:
```{python}
ADAPTIVE_DAMPING = GradientNormDamping(
    damping_scale=ADAPTIVE_SCALE, min_damping=MIN_DAMPING
)
logits = model(X)
loss = loss_function(logits, y)
loss.backward()

gradients = [p.grad.detach().clone() for p in params.values()]
damping = (
     ADAPTIVE_DAMPING(gradients) if use_adaptive_damping else FIXED_DAMPING
  )
```

**Results**
On Cifar10, we set $c = 0.1$ for adaptive damping, and $\lambda = 0.1$ for fixed damping, and train CNN and ResNet18 with identical settings for other hyperparameters:

<img width="2560" height="696" alt="adaptive_damping_convergence" src="https://github.com/user-attachments/assets/93f41cd2-38ad-44c0-8b1b-c2b92a887944" />
<img width="2603" height="696" alt="adaptive_damping_small_cnn_convergence" src="https://github.com/user-attachments/assets/656641e7-21ff-474f-9e37-427056bd66f6" />


