### PR TITLE
[REF] Scope FX `requires_grad` mutation to tracing only

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -105,6 +105,18 @@ See [PR #283](https://github.com/f-dangel/curvlinops/pull/283) for details.
 
 ### Internal
 
+- Scope the FX backends' `requires_grad` mutation to tracing only.
+  `MakeFxKFACComputer` / `MakeFxKFOCComputer` previously flipped
+  `requires_grad=True` on every tensor in the user's `params` dict at
+  ``__init__`` with no restore (a silent side effect on user-owned
+  tensors, e.g., re-enabling gradient tracking on a frozen layer).
+  Wrap the `make_fx` call sites with the existing save/restore
+  `_enable_requires_grad` context manager (now in `utils.py`) so any
+  prior `requires_grad` state is preserved after `compute()` returns.
+  KFOC's `compute()` now traces its IO getter and replays under
+  `no_grad()` to keep the autograd-using portion contained inside an
+  FX graph
+
 - Add `intermediate_as_batch` flag to the FX backend's
   `make_compute_kfac_io_batch` (opt-in unflattened IO — with
   `FisherType.TYPE2`, the collector output directly reconstructs the exact

--- a/curvlinops/_empirical_risk.py
+++ b/curvlinops/_empirical_risk.py
@@ -1,7 +1,6 @@
 """Mixin for classes that iterate over data to compute empirical risk quantities."""
 
 from collections.abc import Callable, Iterable, Iterator, MutableMapping
-from contextlib import contextmanager
 
 from torch import Tensor, device, dtype, tensor, zeros_like
 from torch.autograd import grad
@@ -10,31 +9,12 @@ from torch.nn import CrossEntropyLoss, Module
 from tqdm import tqdm
 
 from curvlinops.utils import (
+    _enable_requires_grad,
     _infer_device,
     _infer_dtype,
     allclose_report,
     make_functional_call,
 )
-
-
-@contextmanager
-def _enable_requires_grad(tensors: list[Tensor]):
-    """Temporarily enable ``requires_grad`` on tensors, restoring original state after.
-
-    Args:
-        tensors: List of tensors to enable gradients on.
-
-    Yields:
-        None.
-    """
-    original = [t.requires_grad for t in tensors]
-    for t in tensors:
-        t.requires_grad_(True)
-    try:
-        yield
-    finally:
-        for t, rg in zip(tensors, original):
-            t.requires_grad_(rg)
 
 
 class _EmpiricalRiskMixin:

--- a/curvlinops/computers/ekfac_make_fx.py
+++ b/curvlinops/computers/ekfac_make_fx.py
@@ -23,7 +23,7 @@ from curvlinops.computers.kfac_make_fx import (
     make_group_gatherers,
 )
 from curvlinops.kfac_utils import FisherType, KFACType
-from curvlinops.utils import _make_fx, fork_rng_with_seed
+from curvlinops.utils import _enable_requires_grad, _make_fx, fork_rng_with_seed
 
 
 def make_compute_ekfac_eigencorrection_batch(
@@ -150,9 +150,14 @@ def make_compute_ekfac_eigencorrection_batch(
                 d_in, d_in, dtype=p1.dtype, device=p1.device
             )
 
-    traced_fn = _make_fx(compute_eigencorrection_batch)(
-        params, X, y, example_input_eigvecs, example_gradient_eigvecs
-    )
+    # ``make_fx`` traces the autograd.grad call inside the closure into
+    # explicit backward aten ops. ``params`` must therefore be differentiable
+    # at trace time; the wrap is local to this call so any prior
+    # ``requires_grad`` state on the user's tensors is restored after tracing.
+    with _enable_requires_grad(list(params.values())):
+        traced_fn = _make_fx(compute_eigencorrection_batch)(
+            params, X, y, example_input_eigvecs, example_gradient_eigvecs
+        )
 
     return traced_fn, mapping
 

--- a/curvlinops/computers/kfac_make_fx.py
+++ b/curvlinops/computers/kfac_make_fx.py
@@ -24,7 +24,7 @@ from curvlinops.computers.kfac_math import (
     input_to_weight_sharing_format,
 )
 from curvlinops.kfac_utils import FisherType, KFACType
-from curvlinops.utils import _make_fx, fork_rng_with_seed
+from curvlinops.utils import _enable_requires_grad, _make_fx, fork_rng_with_seed
 
 
 def _build_param_groups_from_io(
@@ -436,7 +436,12 @@ def make_compute_kfac_batch(
 
         return input_covs, gradient_covs
 
-    traced_fn = _make_fx(compute_batch)(params, X, y)
+    # ``make_fx`` traces the autograd.grad call inside ``compute_batch`` into
+    # explicit backward aten ops. ``params`` must therefore be differentiable
+    # at trace time; the wrap is local to this call so any prior
+    # ``requires_grad`` state on the user's tensors is restored after tracing.
+    with _enable_requires_grad(list(params.values())):
+        traced_fn = _make_fx(compute_batch)(params, X, y)
 
     return traced_fn, mapping
 
@@ -453,12 +458,6 @@ class MakeFxKFACComputer(_BaseKFACComputer):
 
     Supports plain callable ``model_func``.
     """
-
-    def __init__(self, *args, **kwargs):
-        """Initialize and enable gradients on params for autograd.grad."""
-        super().__init__(*args, **kwargs)
-        for p in self._params.values():
-            p.requires_grad_(True)
 
     def _trace_batch_functions(
         self,

--- a/curvlinops/computers/kfoc_make_fx.py
+++ b/curvlinops/computers/kfoc_make_fx.py
@@ -20,7 +20,7 @@ from einops import einsum
 from numpy import eye as np_eye
 from numpy.linalg import svd as np_svd
 from scipy.sparse.linalg import ArpackError, svds
-from torch import Tensor, as_tensor, device, dtype
+from torch import Tensor, as_tensor, device, dtype, no_grad
 
 from curvlinops._torch_base import PyTorchLinearOperator
 from curvlinops.computers._base import ParamGroup, ParamGroupKey, _BaseKFACComputer
@@ -29,7 +29,7 @@ from curvlinops.computers.kfac_make_fx import (
     make_group_gatherers,
 )
 from curvlinops.kfac_utils import FisherType, KFACType
-from curvlinops.utils import _assert_single_element
+from curvlinops.utils import _assert_single_element, _enable_requires_grad, _make_fx
 
 
 class _RearrangedGGNLinearOperator(PyTorchLinearOperator):
@@ -195,11 +195,9 @@ class MakeFxKFOCComputer(_BaseKFACComputer):
     _SUPPORTED_KFAC_APPROX: tuple[KFACType, ...] = (KFACType.EXPAND,)
 
     def __init__(self, *args, **kwargs):
-        """Validate single-batch data and enable grad on params."""
+        """Validate single-batch data."""
         super().__init__(*args, **kwargs)
         _assert_single_element(self._data)
-        for p in self._params.values():
-            p.requires_grad_(True)
 
     def compute(
         self,
@@ -239,9 +237,14 @@ class MakeFxKFOCComputer(_BaseKFACComputer):
             separate_weight_and_bias=self._separate_weight_and_bias,
             intermediate_as_batch=False,
         )
-        layer_inputs, layer_output_grads = inputs_and_grad_outputs_batch(
-            self._params, X, y
-        )
+        # Trace the IO getter to lower its ``autograd.grad`` call into explicit
+        # backward aten ops, then replay with autograd disabled. The
+        # ``_enable_requires_grad`` wrap is local to the trace call so the
+        # user's ``requires_grad`` state is untouched after ``compute`` returns.
+        with _enable_requires_grad(list(self._params.values())):
+            traced_io = _make_fx(inputs_and_grad_outputs_batch)(self._params, X, y)
+        with no_grad():
+            layer_inputs, layer_output_grads = traced_io(self._params, X, y)
         group_inputs, group_grads = make_group_gatherers(
             io_groups, io_param_names, layer_hparams, KFACType.EXPAND
         )

--- a/curvlinops/utils.py
+++ b/curvlinops/utils.py
@@ -76,6 +76,26 @@ def _seed_generator(generator: Generator | None, dev: device, seed: int) -> Gene
 
 
 @contextmanager
+def _enable_requires_grad(tensors: list[Tensor]) -> Iterator[None]:
+    """Temporarily enable ``requires_grad`` on tensors, restoring original state after.
+
+    Args:
+        tensors: List of tensors to enable gradients on.
+
+    Yields:
+        None.
+    """
+    original = [t.requires_grad for t in tensors]
+    for t in tensors:
+        t.requires_grad_(True)
+    try:
+        yield
+    finally:
+        for t, rg in zip(tensors, original):
+            t.requires_grad_(rg)
+
+
+@contextmanager
 def fork_rng_with_seed(seed: int | None) -> Iterator[None]:
     """Fork the global RNG state and seed it, restoring on exit.
 

--- a/test/computers/test_kfoc.py
+++ b/test/computers/test_kfoc.py
@@ -22,6 +22,7 @@ from torch.nn import Linear, Module, MSELoss, Sequential
 
 from curvlinops import GGNLinearOperator, KFOCLinearOperator
 from curvlinops.utils import allclose_report
+from test.test_kfac import _check_does_not_affect_requires_grad
 from test.utils import block_diagonal, change_dtype, eye_like
 
 
@@ -231,35 +232,8 @@ def test_kfoc_handles_zero_ggn():
 
 
 def test_kfoc_make_fx_preserves_requires_grad():
-    """KFOC's FX backend must not mutate the user's ``requires_grad`` flags.
-
-    The IO getter is traced under an ``_enable_requires_grad`` wrap; the
-    flags on user-owned tensors must be restored after ``compute()`` runs.
-    """
-    manual_seed(0)
-    # Two layers so freezing one parameter still leaves an autograd graph
-    # for ``autograd.grad`` to trace through.
-    model = Sequential(Linear(4, 5), Linear(5, 2))
-    model[0].bias.requires_grad_(False)
-    loss_func = MSELoss(reduction="sum")
-    params = dict(model.named_parameters())
-    requires_grad_before = {n: p.requires_grad for n, p in params.items()}
-    assert requires_grad_before == {
-        "0.weight": True,
-        "0.bias": False,
-        "1.weight": True,
-        "1.bias": True,
-    }
-    X = rand(3, 4)
-    y = rand(3, 2)
-
-    KFOCLinearOperator(model, loss_func, params, [(X, y)])
-
-    for n, p in params.items():
-        assert p.requires_grad == requires_grad_before[n], (
-            f"KFOC mutated requires_grad on {n!r}: "
-            f"{requires_grad_before[n]} -> {p.requires_grad}"
-        )
+    """KFOC's FX backend must not mutate the user's ``requires_grad`` flags."""
+    _check_does_not_affect_requires_grad(KFOCLinearOperator)
 
 
 def test_kfoc_rejects_multi_batch():

--- a/test/computers/test_kfoc.py
+++ b/test/computers/test_kfoc.py
@@ -230,6 +230,38 @@ def test_kfoc_handles_zero_ggn():
     assert K.abs().max().item() == 0.0
 
 
+def test_kfoc_make_fx_preserves_requires_grad():
+    """KFOC's FX backend must not mutate the user's ``requires_grad`` flags.
+
+    The IO getter is traced under an ``_enable_requires_grad`` wrap; the
+    flags on user-owned tensors must be restored after ``compute()`` runs.
+    """
+    manual_seed(0)
+    # Two layers so freezing one parameter still leaves an autograd graph
+    # for ``autograd.grad`` to trace through.
+    model = Sequential(Linear(4, 5), Linear(5, 2))
+    model[0].bias.requires_grad_(False)
+    loss_func = MSELoss(reduction="sum")
+    params = dict(model.named_parameters())
+    requires_grad_before = {n: p.requires_grad for n, p in params.items()}
+    assert requires_grad_before == {
+        "0.weight": True,
+        "0.bias": False,
+        "1.weight": True,
+        "1.bias": True,
+    }
+    X = rand(3, 4)
+    y = rand(3, 2)
+
+    KFOCLinearOperator(model, loss_func, params, [(X, y)])
+
+    for n, p in params.items():
+        assert p.requires_grad == requires_grad_before[n], (
+            f"KFOC mutated requires_grad on {n!r}: "
+            f"{requires_grad_before[n]} -> {p.requires_grad}"
+        )
+
+
 def test_kfoc_rejects_multi_batch():
     """Multi-batch input raises at factor computation."""
     manual_seed(0)

--- a/test/test_ekfac.py
+++ b/test/test_ekfac.py
@@ -29,6 +29,7 @@ from test.test_kfac import (
     MC_TOLS,
     _check_callable_model_func,
     _check_does_not_affect_grad,
+    _check_does_not_affect_requires_grad,
     _check_make_fx_flatten_different_batch_sizes,
     _check_torch_save_load,
     _test_weight_tying_type2,
@@ -644,6 +645,11 @@ def test_logdet(inv_case):
 def test_ekfac_does_not_affect_grad():
     """Make sure EKFAC computation does not write to `.grad`."""
     _check_does_not_affect_grad(EKFACLinearOperator)
+
+
+def test_ekfac_make_fx_preserves_requires_grad():
+    """EKFAC's FX backend must not mutate the user's ``requires_grad`` flags."""
+    _check_does_not_affect_requires_grad(EKFACLinearOperator)
 
 
 def test_ekfac_torch_save_load(tmp_path: Path) -> None:

--- a/test/test_ekfac.py
+++ b/test/test_ekfac.py
@@ -649,7 +649,7 @@ def test_ekfac_does_not_affect_grad():
 
 def test_ekfac_make_fx_preserves_requires_grad():
     """EKFAC's FX backend must not mutate the user's ``requires_grad`` flags."""
-    _check_does_not_affect_requires_grad(EKFACLinearOperator)
+    _check_does_not_affect_requires_grad(EKFACLinearOperator, backend="make_fx")
 
 
 def test_ekfac_torch_save_load(tmp_path: Path) -> None:

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -1055,7 +1055,7 @@ def test_kfac_does_not_affect_grad():
     _check_does_not_affect_grad(KFACLinearOperator)
 
 
-def _check_does_not_affect_requires_grad(linop_cls):
+def _check_does_not_affect_requires_grad(linop_cls, **linop_kwargs):
     """Make sure that computing a linear operator does not flip ``requires_grad``.
 
     The FX backend traces ``autograd.grad`` through the model and needs
@@ -1065,6 +1065,9 @@ def _check_does_not_affect_requires_grad(linop_cls):
 
     Args:
         linop_cls: The linear operator class to test.
+        **linop_kwargs: Extra keyword arguments forwarded to ``linop_cls``
+            (e.g., ``backend="make_fx"`` for KFAC/EKFAC; KFOC has no
+            ``backend`` arg and forwards nothing).
     """
     manual_seed(0)
     batch_size, D_in, D_hidden, D_out = 4, 3, 5, 2
@@ -1087,7 +1090,7 @@ def _check_does_not_affect_requires_grad(linop_cls):
 
     # Construct each FX backend (constructors run ``compute()`` via the
     # determinism check, which is the trace path that used to mutate flags).
-    linop_cls(model, MSELoss(), params, [(X, y)], backend="make_fx")
+    linop_cls(model, MSELoss(), params, [(X, y)], **linop_kwargs)
 
     for n, p in params.items():
         assert p.requires_grad == requires_grad_before[n], (
@@ -1098,7 +1101,7 @@ def _check_does_not_affect_requires_grad(linop_cls):
 
 def test_kfac_make_fx_preserves_requires_grad():
     """KFAC's FX backend must not mutate the user's ``requires_grad`` flags."""
-    _check_does_not_affect_requires_grad(KFACLinearOperator)
+    _check_does_not_affect_requires_grad(KFACLinearOperator, backend="make_fx")
 
 
 def _check_torch_save_load(linop_cls: type, tmp_path: Path) -> None:

--- a/test/test_kfac.py
+++ b/test/test_kfac.py
@@ -1055,6 +1055,52 @@ def test_kfac_does_not_affect_grad():
     _check_does_not_affect_grad(KFACLinearOperator)
 
 
+def _check_does_not_affect_requires_grad(linop_cls):
+    """Make sure that computing a linear operator does not flip ``requires_grad``.
+
+    The FX backend traces ``autograd.grad`` through the model and needs
+    ``requires_grad=True`` on params during tracing — but it must restore the
+    original state afterwards, otherwise a frozen parameter passed by the user
+    silently becomes trainable for the rest of the program.
+
+    Args:
+        linop_cls: The linear operator class to test.
+    """
+    manual_seed(0)
+    batch_size, D_in, D_hidden, D_out = 4, 3, 5, 2
+    X = rand(batch_size, D_in)
+    y = rand(batch_size, D_out)
+    # Two layers so we can freeze one parameter while the other keeps the
+    # autograd graph alive (with everything frozen, ``autograd.grad`` would
+    # have nothing to differentiate against).
+    model = Sequential(Linear(D_in, D_hidden), Linear(D_hidden, D_out))
+    model[0].bias.requires_grad_(False)
+
+    params = dict(model.named_parameters())
+    requires_grad_before = {n: p.requires_grad for n, p in params.items()}
+    assert requires_grad_before == {
+        "0.weight": True,
+        "0.bias": False,
+        "1.weight": True,
+        "1.bias": True,
+    }
+
+    # Construct each FX backend (constructors run ``compute()`` via the
+    # determinism check, which is the trace path that used to mutate flags).
+    linop_cls(model, MSELoss(), params, [(X, y)], backend="make_fx")
+
+    for n, p in params.items():
+        assert p.requires_grad == requires_grad_before[n], (
+            f"FX backend mutated requires_grad on {n!r}: "
+            f"{requires_grad_before[n]} -> {p.requires_grad}"
+        )
+
+
+def test_kfac_make_fx_preserves_requires_grad():
+    """KFAC's FX backend must not mutate the user's ``requires_grad`` flags."""
+    _check_does_not_affect_requires_grad(KFACLinearOperator)
+
+
 def _check_torch_save_load(linop_cls: type, tmp_path: Path) -> None:
     """Test that an (E)KFAC operator can be saved and loaded with torch.save/load.
 


### PR DESCRIPTION
## Summary

- KFAC/KFOC's FX computers previously flipped `requires_grad=True` on every tensor in the user's `params` dict at `__init__`, with **no restore** — a silent side effect on user-owned tensors (e.g., re-enabling gradient tracking on a frozen layer for the rest of the user's program).
- Apply the principle "whoever knowingly invokes autograd owns the `requires_grad` wrap": wrap `make_fx` call sites with the existing save/restore `_enable_requires_grad` context manager.
- Move `_enable_requires_grad` from `_empirical_risk.py` to `utils.py` since it's now shared across `_empirical_risk` and the three FX backends.

### Changes

- `kfac_make_fx.py`: wrap `_make_fx(compute_batch)(params, X, y)` inside `make_compute_kfac_batch`. Drop `MakeFxKFACComputer.__init__` mutation.
- `ekfac_make_fx.py`: wrap `_make_fx(...)` inside `make_compute_ekfac_eigencorrection_batch` (its other tracing path goes through the KFAC factory, already covered).
- `kfoc_make_fx.py`: trace the IO getter (`inputs_and_grad_outputs_batch`) inside `compute()` with the wrap, then replay under `no_grad()`. Drop `MakeFxKFOCComputer.__init__` mutation.
- `utils.py`: house `_enable_requires_grad`. `_empirical_risk.py` re-imports.
- `changelog.md`: Internal entry.

### Why this works

`make_fx` lowers `autograd.grad` into explicit backward aten ops baked into the FX graph; replay runs under `no_grad()` and doesn't depend on `requires_grad` on params. So `requires_grad=True` is only needed at trace time, and the save/restore wrap leaves the user's tensors in their original state after `compute()` returns.

## Test plan

- [x] `pytest test/computers/test_kfoc.py` (40 passed)
- [x] `pytest test/test_kfac.py` (776 passed, 11 skipped)
- [x] `pytest test/test_ekfac.py` (572 passed)
- [x] `pytest test/test_hessian.py test/test_gradient_moments.py` (34 passed — empirical-risk consumers of the moved context manager)
- [x] `ruff check` + `ruff format --check` pass
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)