### PR TITLE
[REF] Migrate KFOC FX backend to `LayerIO`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -111,6 +111,11 @@ See [PR #283](https://github.com/f-dangel/curvlinops/pull/283) for details.
   public API and behavior are unchanged. EKFAC and KFOC migrations follow
   in subsequent PRs
 
+- Migrate `MakeFxKFOCComputer` to use `LayerIO` (with
+  `intermediate_as_batch=False`) and `LayerIOSnapshot.per_sample_grads`
+  instead of the lower-level `make_compute_kfac_io_batch` /
+  `make_group_gatherers` helpers. Public KFOC API and numerics are unchanged
+
 - Scope the FX backends' `requires_grad` mutation to tracing only.
   `MakeFxKFACComputer` / `MakeFxKFOCComputer` previously flipped
   `requires_grad=True` on every tensor in the user's `params` dict at

--- a/changelog.md
+++ b/changelog.md
@@ -110,11 +110,13 @@ See [PR #283](https://github.com/f-dangel/curvlinops/pull/283) for details.
   collection plumbing. Migrate the FX KFAC backend to use it; `KFAC`'s
   public API and behavior are unchanged. EKFAC and KFOC migrations follow
   in subsequent PRs
+  ([PR](https://github.com/f-dangel/curvlinops/pull/302))
 
 - Migrate `MakeFxKFOCComputer` to use `LayerIO` (with
   `intermediate_as_batch=False`) and `LayerIOSnapshot.per_sample_grads`
   instead of the lower-level `make_compute_kfac_io_batch` /
   `make_group_gatherers` helpers. Public KFOC API and numerics are unchanged
+  ([PR](https://github.com/f-dangel/curvlinops/pull/303))
 
 - Scope the FX backends' `requires_grad` mutation to tracing only.
   `MakeFxKFACComputer` / `MakeFxKFOCComputer` previously flipped
@@ -127,6 +129,7 @@ See [PR #283](https://github.com/f-dangel/curvlinops/pull/283) for details.
   KFOC's `compute()` now traces its IO getter and replays under
   `no_grad()` to keep the autograd-using portion contained inside an
   FX graph
+  ([PR](https://github.com/f-dangel/curvlinops/pull/301))
 
 - Add `intermediate_as_batch` flag to the FX backend's
   `make_compute_kfac_io_batch` (opt-in unflattened IO — with

--- a/curvlinops/computers/kfoc_make_fx.py
+++ b/curvlinops/computers/kfoc_make_fx.py
@@ -6,10 +6,9 @@ Provides:
   Gauss-Newton block, exposed as a rectangular PyTorch linear operator whose
   matvec consumes per-sample ``vec(W)`` gradients.
 - :class:`MakeFxKFOCComputer`: FX-based computer that obtains per-sample
-  activations and output gradients via :func:`make_compute_kfac_io_batch`
-  with ``intermediate_as_batch=False``, forms per-sample ``vec(W)`` gradients,
-  and extracts Kronecker factors per layer via truncated SVD on the
-  rearranged operator.
+  activations and output gradients via :class:`LayerIO` with
+  ``intermediate_as_batch=False`` and extracts Kronecker factors per layer via
+  truncated SVD on the rearranged operator.
 """
 
 from __future__ import annotations
@@ -24,12 +23,9 @@ from torch import Tensor, as_tensor, device, dtype, no_grad
 
 from curvlinops._torch_base import PyTorchLinearOperator
 from curvlinops.computers._base import ParamGroup, ParamGroupKey, _BaseKFACComputer
-from curvlinops.computers.kfac_make_fx import (
-    make_compute_kfac_io_batch,
-    make_group_gatherers,
-)
+from curvlinops.computers.io_collector import LayerIO
 from curvlinops.kfac_utils import FisherType, KFACType
-from curvlinops.utils import _assert_single_element, _enable_requires_grad, _make_fx
+from curvlinops.utils import _assert_single_element, _make_fx
 
 
 class _RearrangedGGNLinearOperator(PyTorchLinearOperator):
@@ -182,10 +178,10 @@ def _top_rank_one_kron_factors(
 class MakeFxKFOCComputer(_BaseKFACComputer):
     """KFOC computer: top-1 SVD on the rearranged per-layer GGN block.
 
-    Collects per-sample activations and output gradients via the unflattened
-    IO collector (``intermediate_as_batch=False``), forms per-sample
-    ``vec(W)`` gradients, and extracts the Frobenius-optimal rank-1 Kronecker
-    factors from the top singular pair of the rearranged operator.
+    Collects per-sample activations and output gradients via :class:`LayerIO`
+    with ``intermediate_as_batch=False``, forms per-sample ``vec(W)`` gradients,
+    and extracts the Frobenius-optimal rank-1 Kronecker factors from the top
+    singular pair of the rearranged operator.
 
     Requires ``FisherType.TYPE2``, ``KFACType.EXPAND``, and exactly one batch
     in ``data``. All three preconditions fail at construction.
@@ -221,58 +217,52 @@ class MakeFxKFOCComputer(_BaseKFACComputer):
         # yields CPU tensors.
         X, y = next(iter(self._loop_over_data()))
 
-        (
-            inputs_and_grad_outputs_batch,
-            mapping,
-            io_groups,
-            io_param_names,
-            layer_hparams,
-        ) = make_compute_kfac_io_batch(
+        io = LayerIO(
             self._model_func,
             self._loss_func,
             self._params,
             X,
             fisher_type=self._fisher_type,
             mc_samples=self._mc_samples,
+            kfac_approx=self._kfac_approx,
             separate_weight_and_bias=self._separate_weight_and_bias,
             intermediate_as_batch=False,
+            batch_size_fn=self._batch_size_fn,
         )
-        # Trace the IO getter to lower its ``autograd.grad`` call into explicit
-        # backward aten ops, then replay with autograd disabled. The
-        # ``_enable_requires_grad`` wrap is local to the trace call so the
-        # user's ``requires_grad`` state is untouched after ``compute`` returns.
-        with _enable_requires_grad(list(self._params.values())):
-            traced_io = _make_fx(inputs_and_grad_outputs_batch)(self._params, X, y)
+        # Trace IO collection only (the SVD per group is non-traceable due to
+        # ``svds`` + ARPACK error handling), then replay under ``no_grad`` to
+        # keep the autograd-using portion contained inside the FX graph.
+        # The wrapper hides ``io.populate``'s bound ``self`` from ``make_fx``,
+        # which otherwise counts it as a tracing argument.
+
+        def populate(params, X, y):
+            return io.populate(params, X, y)
+
+        with io.enable_param_grads(self._params):
+            traced_populate = _make_fx(populate)(self._params, X, y)
         with no_grad():
-            layer_inputs, layer_output_grads = traced_io(self._params, X, y)
-        group_inputs, group_grads = make_group_gatherers(
-            io_groups, io_param_names, layer_hparams, KFACType.EXPAND
-        )
+            layer_inputs, layer_output_grads = traced_populate(self._params, X, y)
+        snap = io.snapshot(layer_inputs, layer_output_grads)
 
         # ``S_1 (otimes) S_2`` per group; positional return matches the base
         # class slots (``input_covariances``, ``gradient_covariances``).
         first_factors: dict[ParamGroupKey, Tensor] = {}
         second_factors: dict[ParamGroupKey, Tensor] = {}
-        for group in mapping:
+        for group in io.mapping:
             group_key = tuple(group.values())
-            g = group_grads(group, layer_output_grads)
+            per_sample_grads = snap.per_sample_grads(group)
             if "W" in group:
-                a = group_inputs(group, layer_inputs)
-                per_sample_grads = einsum(
-                    g, a, "vec batch shared out, batch shared inp -> vec batch out inp"
-                )
                 S_1, S_2 = _top_rank_one_kron_factors(per_sample_grads)
                 first_factors[group_key] = S_1
                 second_factors[group_key] = S_2
             else:
                 # Bias-only block: the Frobenius optimum is the exact GGN
-                # block. The bias is shared across the ``shared`` axis, so
-                # per-sample gradients sum over it before the outer product.
-                g_per_sample = einsum(g, "vec batch shared row -> vec batch row")
+                # block. ``per_sample_grads`` already sums over the shared
+                # axis, so the outer product runs straight on ``[V, B, d_out]``.
                 first_factors[group_key] = einsum(
-                    g_per_sample,
-                    g_per_sample,
+                    per_sample_grads,
+                    per_sample_grads,
                     "vec batch row, vec batch col -> row col",
                 )
 
-        return second_factors, first_factors, mapping
+        return second_factors, first_factors, io.mapping


### PR DESCRIPTION
## Summary

- Migrates `MakeFxKFOCComputer` to use the `LayerIO` orchestration introduced in #302 (with `intermediate_as_batch=False`), replacing the lower-level `make_compute_kfac_io_batch` / `make_group_gatherers` calls.
- Per-layer per-sample `vec(W)` gradients (and the bias-only equivalent) come from `LayerIOSnapshot.per_sample_grads`, which already handles the W and bias-only paths.
- The SVD/eigh per group stays out of the FX trace; only `io.populate` is traced and replayed under `no_grad()`.
- Public KFOC API and numerics are unchanged.

## Test plan

- [x] `pytest test/computers/test_kfoc.py` — all 41 tests pass
- [x] `pytest test/computers/test_layer_io.py test/computers/test_kfac_io.py test/test_kfac.py test/test_ekfac.py` — 1377 passed, 11 skipped
- [x] `ruff check` and `ruff format --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)