### PR TITLE
Support FisherType.MC in KFOCLinearOperator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,8 @@ See [PR #283](https://github.com/f-dangel/curvlinops/pull/283) for details.
   replaced. Scope: single-batch data, `fisher_type` in `{TYPE2, MC}`
   (defaults to `MC`, mirroring `KFACLinearOperator`).
   References: Schnaus, Lee, Triebel (BDL@NeurIPS 2021); Koroko et al. (arXiv:2201.10285)
-  ([PR](https://github.com/f-dangel/curvlinops/pull/299))
+  ([PR](https://github.com/f-dangel/curvlinops/pull/299),
+  [PR](https://github.com/f-dangel/curvlinops/pull/305))
 
 - Add preconditioner support to `NeumannInverseLinearOperator` via a new
   `preconditioner` argument, enabling the preconditioned Neumann/Richardson

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,8 @@ See [PR #283](https://github.com/f-dangel/curvlinops/pull/283) for details.
   pair of the block's Van Loan rearrangement (bias-only blocks store the
   exact bias GGN). Subclasses `KFACLinearOperator` and reuses the inherited
   matvec/inverse/eigh machinery; only the factor-computation step is
-  replaced. Scope: single-batch data, `FisherType.TYPE2`.
+  replaced. Scope: single-batch data, `fisher_type` in `{TYPE2, MC}`
+  (defaults to `MC`, mirroring `KFACLinearOperator`).
   References: Schnaus, Lee, Triebel (BDL@NeurIPS 2021); Koroko et al. (arXiv:2201.10285)
   ([PR](https://github.com/f-dangel/curvlinops/pull/299))
 

--- a/curvlinops/computers/kfoc_make_fx.py
+++ b/curvlinops/computers/kfoc_make_fx.py
@@ -25,7 +25,7 @@ from curvlinops._torch_base import PyTorchLinearOperator
 from curvlinops.computers._base import ParamGroup, ParamGroupKey, _BaseKFACComputer
 from curvlinops.computers.io_collector import LayerIO
 from curvlinops.kfac_utils import FisherType, KFACType
-from curvlinops.utils import _assert_single_element, _make_fx
+from curvlinops.utils import _assert_single_element, _make_fx, fork_rng_with_seed
 
 
 class _RearrangedGGNLinearOperator(PyTorchLinearOperator):
@@ -183,11 +183,12 @@ class MakeFxKFOCComputer(_BaseKFACComputer):
     and extracts the Frobenius-optimal rank-1 Kronecker factors from the top
     singular pair of the rearranged operator.
 
-    Requires ``FisherType.TYPE2``, ``KFACType.EXPAND``, and exactly one batch
-    in ``data``. All three preconditions fail at construction.
+    Requires ``FisherType`` in ``{TYPE2, MC}``, ``KFACType.EXPAND``, and
+    exactly one batch in ``data``. All three preconditions fail at
+    construction.
     """
 
-    _SUPPORTED_FISHER_TYPE: tuple[FisherType, ...] = (FisherType.TYPE2,)
+    _SUPPORTED_FISHER_TYPE: tuple[FisherType, ...] = (FisherType.TYPE2, FisherType.MC)
     _SUPPORTED_KFAC_APPROX: tuple[KFACType, ...] = (KFACType.EXPAND,)
 
     def __init__(self, *args, **kwargs):
@@ -239,7 +240,10 @@ class MakeFxKFOCComputer(_BaseKFACComputer):
 
         with io.enable_param_grads(self._params):
             traced_populate = _make_fx(populate)(self._params, X, y)
-        with no_grad():
+        # Seed only for stochastic fisher types so MC draws are reproducible
+        # without leaking into the caller's global RNG state.
+        seed = self._seed if self._fisher_type == FisherType.MC else None
+        with fork_rng_with_seed(seed), no_grad():
             layer_inputs, layer_output_grads = traced_populate(self._params, X, y)
         snap = io.snapshot(layer_inputs, layer_output_grads)
 

--- a/curvlinops/computers/kfoc_make_fx.py
+++ b/curvlinops/computers/kfoc_make_fx.py
@@ -240,8 +240,8 @@ class MakeFxKFOCComputer(_BaseKFACComputer):
 
         with io.enable_param_grads(self._params):
             traced_populate = _make_fx(populate)(self._params, X, y)
-        # Seed only for stochastic fisher types so MC draws are reproducible
-        # without leaking into the caller's global RNG state.
+        # Seed only for stochastic fisher types. fork_rng_with_seed isolates
+        # the seed from the caller's global RNG state.
         seed = self._seed if self._fisher_type == FisherType.MC else None
         with fork_rng_with_seed(seed), no_grad():
             layer_inputs, layer_output_grads = traced_populate(self._params, X, y)

--- a/curvlinops/kfoc.py
+++ b/curvlinops/kfoc.py
@@ -31,7 +31,7 @@ class KFOCLinearOperator(KFACLinearOperator):
 
     Scope:
         - Single-batch data only (``len(list(data)) == 1``).
-        - :class:`FisherType.TYPE2` only.
+        - ``fisher_type`` in ``{FisherType.TYPE2, FisherType.MC}``.
 
     References:
         - Schnaus, D., Lee, J., Triebel, R. (2021). "Kronecker-Factored Optimal
@@ -54,6 +54,9 @@ class KFOCLinearOperator(KFACLinearOperator):
         data: Iterable[tuple[Tensor | MutableMapping, Tensor]],
         progressbar: bool = False,
         check_deterministic: bool = True,
+        seed: int = 2_147_483_647,
+        fisher_type: str = FisherType.MC,
+        mc_samples: int = 1,
         separate_weight_and_bias: bool = True,
         num_data: int | None = None,
         batch_size_fn: Callable[[MutableMapping | Tensor], int] | None = None,
@@ -68,6 +71,17 @@ class KFOCLinearOperator(KFACLinearOperator):
             data: Iterable of a single ``(X, y)`` batch.
             progressbar: Whether to show a progress bar.
             check_deterministic: Whether to run the determinism check on init.
+            seed: Seed for the random number generator used to draw labels
+                from the model's predictive distribution. Only used when
+                ``fisher_type == FisherType.MC``. Defaults to ``2147483647``.
+            fisher_type: The type of Fisher/GGN to approximate. If
+                ``FisherType.TYPE2``, the exact Hessian of the loss w.r.t. the
+                model outputs is used. If ``FisherType.MC``, the expectation is
+                approximated by sampling ``mc_samples`` labels from the model's
+                predictive distribution. Defaults to ``FisherType.MC``.
+            mc_samples: The number of Monte-Carlo samples to use per data
+                point. Has to be set to ``1`` when
+                ``fisher_type != FisherType.MC``. Defaults to ``1``.
             separate_weight_and_bias: Whether to treat weight and bias as
                 separate parameter groups.
             num_data: Total dataset size (here just the single batch size).
@@ -81,8 +95,9 @@ class KFOCLinearOperator(KFACLinearOperator):
             data,
             progressbar=progressbar,
             check_deterministic=check_deterministic,
-            fisher_type=FisherType.TYPE2,
-            mc_samples=1,
+            seed=seed,
+            fisher_type=fisher_type,
+            mc_samples=mc_samples,
             kfac_approx=KFACType.EXPAND,
             separate_weight_and_bias=separate_weight_and_bias,
             num_data=num_data,

--- a/test/computers/test_kfoc.py
+++ b/test/computers/test_kfoc.py
@@ -21,11 +21,33 @@ from torch.linalg import svd as torch_svd
 from torch.nn import Linear, Module, MSELoss, Sequential
 
 from curvlinops import GGNLinearOperator, KFOCLinearOperator
+from curvlinops.kfac_utils import FisherType
 from curvlinops.utils import allclose_report
 from test.utils import block_diagonal, change_dtype, eye_like
 
+_MC_SAMPLES = 4
+_MC_SEED = 12345
 
-def _assert_kfoc_factors_match_dense_svd(case):
+
+def _ggn_mc_kwargs(fisher_type: FisherType) -> dict:
+    """``GGNLinearOperator`` kwargs that match a given KFOC ``fisher_type``.
+
+    For ``MC``, force the same ``mc_samples`` and ``seed`` so the per-sample
+    draws inside ``GGNLinearOperator``'s pseudo-loss line up with the draws
+    inside KFOC's traced ``LayerIO.populate``.
+
+    Args:
+        fisher_type: KFOC's curvature flavor.
+
+    Returns:
+        Empty dict for ``TYPE2``; ``{"mc_samples": ..., "seed": ...}`` for ``MC``.
+    """
+    if fisher_type == FisherType.MC:
+        return {"mc_samples": _MC_SAMPLES, "seed": _MC_SEED}
+    return {}
+
+
+def _assert_kfoc_factors_match_dense_svd(case, fisher_type: FisherType):
     """Assert KFOC's per-layer Kron product matches the top-1 SVD of ``R(G_l)``.
 
     Works in canonical layout: ``K_canonical`` (the middle of ``kfoc``'s
@@ -36,6 +58,9 @@ def _assert_kfoc_factors_match_dense_svd(case):
 
     Args:
         case: Model, loss, parameters, data, and optional batch-size function.
+        fisher_type: Curvature flavor (``TYPE2`` or ``MC``). For ``MC`` the
+            reference ``GGNLinearOperator`` is built with matching
+            ``mc_samples`` and ``seed`` so the per-sample draws match.
     """
     model, loss_func, params, data, batch_size_fn = change_dtype(case, float64)
     X, y = next(iter(data))
@@ -46,6 +71,9 @@ def _assert_kfoc_factors_match_dense_svd(case):
         params,
         [(X, y)],
         batch_size_fn=batch_size_fn,
+        fisher_type=fisher_type,
+        mc_samples=_MC_SAMPLES if fisher_type == FisherType.MC else 1,
+        seed=_MC_SEED,
     )
     _, K_op, PT = kfoc
     K_canonical = K_op @ eye_like(K_op)
@@ -57,6 +85,7 @@ def _assert_kfoc_factors_match_dense_svd(case):
         params,
         [(X, y)],
         batch_size_fn=batch_size_fn,
+        optional_linop_args=_ggn_mc_kwargs(fisher_type),
     )
     ggn_canonical = PT_mat @ ggn @ PT_mat.T
 
@@ -88,7 +117,7 @@ def _assert_kfoc_factors_match_dense_svd(case):
             offset += n
 
 
-def _assert_kfoc_first_order_optimality(case):
+def _assert_kfoc_first_order_optimality(case, fisher_type: FisherType):
     """Assert KFOC's factors are stationary points of the Frobenius residual.
 
     Enable grad on every factor in every block (Kronecker pairs for weight
@@ -100,6 +129,9 @@ def _assert_kfoc_first_order_optimality(case):
 
     Args:
         case: Model, loss, parameters, data, and optional batch-size function.
+        fisher_type: Curvature flavor (``TYPE2`` or ``MC``). For ``MC`` the
+            reference ``GGNLinearOperator`` is built with matching
+            ``mc_samples`` and ``seed`` so the per-sample draws match.
     """
     model, loss_func, params, data, batch_size_fn = change_dtype(case, float64)
     X, y = next(iter(data))
@@ -110,6 +142,9 @@ def _assert_kfoc_first_order_optimality(case):
         params,
         [(X, y)],
         batch_size_fn=batch_size_fn,
+        fisher_type=fisher_type,
+        mc_samples=_MC_SAMPLES if fisher_type == FisherType.MC else 1,
+        seed=_MC_SEED,
     )
     _, K_op, _ = kfoc
     factors = [f.requires_grad_(True) for block in K_op for f in block]
@@ -120,6 +155,7 @@ def _assert_kfoc_first_order_optimality(case):
         params,
         [(X, y)],
         batch_size_fn=batch_size_fn,
+        optional_linop_args=_ggn_mc_kwargs(fisher_type),
     )
     K = kfoc @ eye_like(kfoc)
     loss = (ggn - K).pow(2).sum()
@@ -127,6 +163,7 @@ def _assert_kfoc_first_order_optimality(case):
         assert g.abs().max().item() < 1e-8
 
 
+@mark.parametrize("fisher_type", [FisherType.TYPE2, FisherType.MC])
 def test_kfoc_factors_match_dense_svd(
     case: tuple[
         Module,
@@ -135,20 +172,24 @@ def test_kfoc_factors_match_dense_svd(
         Iterable[tuple[Tensor, Tensor]],
         object,
     ],
+    fisher_type: FisherType,
 ):
     """KFOC's per-layer Kron product matches the top-1 SVD of ``R(G_l)`` (Linear).
 
     The Eckart-Young theorem on the Van Loan rearrangement is the
     closed-form Frobenius minimizer; reshape the GGN block to
     ``R(G_l) ∈ R^(d_out² × d_in²)``, take the top-1 SVD, and check that
-    KFOC's Kron output matches.
+    KFOC's Kron output matches. For ``MC`` the reference is the MC-GGN
+    constructed via ``GGNLinearOperator`` with matching seed.
 
     Args:
         case: Model, loss, parameters, data, and optional batch-size function.
+        fisher_type: Curvature flavor (``TYPE2`` or ``MC``).
     """
-    _assert_kfoc_factors_match_dense_svd(case)
+    _assert_kfoc_factors_match_dense_svd(case, fisher_type)
 
 
+@mark.parametrize("fisher_type", [FisherType.TYPE2, FisherType.MC])
 def test_kfoc_factors_match_dense_svd_cnn(
     cnn_case: tuple[
         Module,
@@ -157,6 +198,7 @@ def test_kfoc_factors_match_dense_svd_cnn(
         Iterable[tuple[Tensor, Tensor]],
         object,
     ],
+    fisher_type: FisherType,
 ):
     """Same as :func:`test_kfoc_factors_match_dense_svd`, on CNN models with Conv2d.
 
@@ -166,10 +208,12 @@ def test_kfoc_factors_match_dense_svd_cnn(
 
     Args:
         cnn_case: Model, loss, parameters, data, and optional batch-size function.
+        fisher_type: Curvature flavor (``TYPE2`` or ``MC``).
     """
-    _assert_kfoc_factors_match_dense_svd(cnn_case)
+    _assert_kfoc_factors_match_dense_svd(cnn_case, fisher_type)
 
 
+@mark.parametrize("fisher_type", [FisherType.TYPE2, FisherType.MC])
 def test_kfoc_first_order_optimality(
     case: tuple[
         Module,
@@ -178,6 +222,7 @@ def test_kfoc_first_order_optimality(
         Iterable[tuple[Tensor, Tensor]],
         object,
     ],
+    fisher_type: FisherType,
 ):
     """KFOC's factors are stationary points of the Frobenius residual (Linear).
 
@@ -189,10 +234,12 @@ def test_kfoc_first_order_optimality(
 
     Args:
         case: Model, loss, parameters, data, and optional batch-size function.
+        fisher_type: Curvature flavor (``TYPE2`` or ``MC``).
     """
-    _assert_kfoc_first_order_optimality(case)
+    _assert_kfoc_first_order_optimality(case, fisher_type)
 
 
+@mark.parametrize("fisher_type", [FisherType.TYPE2, FisherType.MC])
 def test_kfoc_first_order_optimality_cnn(
     cnn_case: tuple[
         Module,
@@ -201,13 +248,15 @@ def test_kfoc_first_order_optimality_cnn(
         Iterable[tuple[Tensor, Tensor]],
         object,
     ],
+    fisher_type: FisherType,
 ):
     """Same as :func:`test_kfoc_first_order_optimality`, on CNN models with Conv2d.
 
     Args:
         cnn_case: Model, loss, parameters, data, and optional batch-size function.
+        fisher_type: Curvature flavor (``TYPE2`` or ``MC``).
     """
-    _assert_kfoc_first_order_optimality(cnn_case)
+    _assert_kfoc_first_order_optimality(cnn_case, fisher_type)
 
 
 def test_kfoc_handles_zero_ggn():
@@ -223,7 +272,9 @@ def test_kfoc_handles_zero_ggn():
     X = zeros(3, 4, dtype=float64)
     y = rand(3, 2, dtype=float64)
 
-    kfoc = KFOCLinearOperator(model, loss_func, params, [(X, y)])
+    kfoc = KFOCLinearOperator(
+        model, loss_func, params, [(X, y)], fisher_type=FisherType.TYPE2
+    )
     K = kfoc @ eye_like(kfoc)
     ggn = block_diagonal(GGNLinearOperator, model, loss_func, params, [(X, y)])
     assert allclose_report(K, ggn)
@@ -238,7 +289,7 @@ def test_kfoc_rejects_multi_batch():
     params = dict(model.named_parameters())
     data = [(rand(2, 4), rand(2, 2)), (rand(3, 4), rand(3, 2))]
     with raises(ValueError, match="more than one"):
-        KFOCLinearOperator(model, loss_func, params, data)
+        KFOCLinearOperator(model, loss_func, params, data, fisher_type=FisherType.TYPE2)
 
 
 @mark.parametrize("d_in,d_out", [(4, 1), (1, 3)], ids=["scalar_out", "scalar_in"])
@@ -259,6 +310,8 @@ def test_kfoc_handles_degenerate_svds_shapes(d_in: int, d_out: int):
     params = dict(model.named_parameters())
     X = rand(3, d_in, dtype=float64)
     y = rand(3, d_out, dtype=float64)
-    kfoc = KFOCLinearOperator(model, loss_func, params, [(X, y)])
+    kfoc = KFOCLinearOperator(
+        model, loss_func, params, [(X, y)], fisher_type=FisherType.TYPE2
+    )
     ggn = block_diagonal(GGNLinearOperator, model, loss_func, params, [(X, y)])
     assert allclose_report(kfoc @ eye_like(kfoc), ggn)

--- a/test/computers/test_kfoc.py
+++ b/test/computers/test_kfoc.py
@@ -29,6 +29,22 @@ _MC_SAMPLES = 4
 _MC_SEED = 12345
 
 
+def _kfoc_mc_kwargs(fisher_type: FisherType) -> dict:
+    """KFOC kwargs pinning ``mc_samples`` and ``seed`` for a given ``fisher_type``.
+
+    Args:
+        fisher_type: KFOC's curvature flavor.
+
+    Returns:
+        ``{fisher_type, mc_samples, seed}`` — ``mc_samples=1`` for non-MC.
+    """
+    return {
+        "fisher_type": fisher_type,
+        "mc_samples": _MC_SAMPLES if fisher_type == FisherType.MC else 1,
+        "seed": _MC_SEED,
+    }
+
+
 def _ggn_mc_kwargs(fisher_type: FisherType) -> dict:
     """``GGNLinearOperator`` kwargs that match a given KFOC ``fisher_type``.
 
@@ -71,9 +87,7 @@ def _assert_kfoc_factors_match_dense_svd(case, fisher_type: FisherType):
         params,
         [(X, y)],
         batch_size_fn=batch_size_fn,
-        fisher_type=fisher_type,
-        mc_samples=_MC_SAMPLES if fisher_type == FisherType.MC else 1,
-        seed=_MC_SEED,
+        **_kfoc_mc_kwargs(fisher_type),
     )
     _, K_op, PT = kfoc
     K_canonical = K_op @ eye_like(K_op)
@@ -142,9 +156,7 @@ def _assert_kfoc_first_order_optimality(case, fisher_type: FisherType):
         params,
         [(X, y)],
         batch_size_fn=batch_size_fn,
-        fisher_type=fisher_type,
-        mc_samples=_MC_SAMPLES if fisher_type == FisherType.MC else 1,
-        seed=_MC_SEED,
+        **_kfoc_mc_kwargs(fisher_type),
     )
     _, K_op, _ = kfoc
     factors = [f.requires_grad_(True) for block in K_op for f in block]


### PR DESCRIPTION
## Summary
- Expose `fisher_type` (default `MC`), `mc_samples`, and `seed` on `KFOCLinearOperator`, mirroring `KFACLinearOperator`'s interface. The underlying `_RearrangedGGNLinearOperator` already supports an arbitrary direction count `V`; this PR only widens the public API.
- Wrap `MakeFxKFOCComputer.compute()`'s `traced_populate(...)` replay in `fork_rng_with_seed(self._seed if MC else None)` so MC draws are reproducible across calls (matches what `MakeFxKFACComputer` already does).
- Existing TYPE2 tests are pinned via explicit `fisher_type=FisherType.TYPE2` to preserve their exact-GGN reference. New MC variants compare bit-exactly against the MC-GGN built via `GGNLinearOperator(mc_samples=4, seed=12345)` with a matching seed.

## Test plan
- [x] `pytest test/computers/test_kfoc.py` — 76 passed (existing TYPE2 + new MC variants of `test_kfoc_factors_match_dense_svd[_cnn]` and `test_kfoc_first_order_optimality[_cnn]`)
- [x] `pytest test/test_kfac.py test/test_ekfac.py test/computers/` — 1554 passed, 11 skipped, 0 failures
- [x] Sanity-check the seed alignment is load-bearing: temporarily mismatched the GGN seed by `+1`; the MC test failed on all 2500/2500 entries as expected, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)