### PR TITLE
[ADD] Detect Linear weights/biases reused across reshape-wrapped matmuls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -279,6 +279,12 @@ See [PR #283](https://github.com/f-dangel/curvlinops/pull/283) for details.
 
 - Generalize IO collector to handle linear layers with >2D inputs
   ([PR](https://github.com/f-dangel/curvlinops/pull/259))
+  - Detect a `Linear`'s weight and bias when the bias is added after
+    last-dim-preserving reshapes, and when one weight is reused across matmuls of
+    differing reshape depth. This enables KFAC/EKFAC (`make_fx` backend) on losses
+    whose graph routes each parameter through such reshapes — e.g. PINN PDE
+    residuals computed via Taylor mode (jet)
+    ([PR](https://github.com/f-dangel/curvlinops/pull/308))
 
 - Add a collector for in/outputs of linear weight sharing layers based on `make_fx`
   ([PR](https://github.com/f-dangel/curvlinops/pull/252))

--- a/curvlinops/computers/io_collector/linear.py
+++ b/curvlinops/computers/io_collector/linear.py
@@ -14,6 +14,95 @@ LINEAR_STR = "Linear(y=W@x+b)"
 # Reshape ops inserted by F.linear for >2D inputs (view → mm/addmm → view)
 _VIEW_OPS = {aten._unsafe_view.default, aten.view.default}
 
+# Shape-only ("transparent") ops that may sit between a matmul and its bias add.
+# Transforms that wrap the matmul (e.g. Taylor-mode / jet, which emits
+# ``mm → _unsafe_view → squeeze → add(bias)``) interleave these; they leave the
+# last (feature) dimension untouched, so a bias add reached through a chain of them
+# still belongs to the matmul.
+_TRANSPARENT_OPS = {
+    aten.view.default,
+    aten._unsafe_view.default,
+    aten.reshape.default,
+    aten.squeeze.dim,
+    aten.squeeze.dims,
+    aten.squeeze.default,
+    aten.unsqueeze.default,
+}
+
+
+def _preserves_last_dim(node: Node) -> bool:
+    """Whether a shape-only op leaves the last (feature) dimension unchanged.
+
+    Args:
+        node: A ``call_function`` shape op with a single tensor input.
+
+    Returns:
+        ``True`` if the node's output last dim equals its input's last dim.
+    """
+    try:
+        return node.meta["val"].shape[-1] == node.args[0].meta["val"].shape[-1]
+    except (KeyError, AttributeError, IndexError, TypeError):
+        return False
+
+
+def _is_transparent(node: Node) -> bool:
+    """Whether a node is a last-dim-preserving transparent shape-only op.
+
+    Args:
+        node: The node to check.
+
+    Returns:
+        ``True`` if the node is a shape-only op that preserves the last dimension.
+    """
+    return (
+        node.op == "call_function"
+        and node.target in _TRANSPARENT_OPS
+        and _preserves_last_dim(node)
+    )
+
+
+def _skip_transparent_forward(node: Node) -> tuple[Node, tuple[Node, ...]]:
+    """Walk forward through single-user transparent shape-only ops.
+
+    Args:
+        node: Node to start from.
+
+    Returns:
+        ``(tail, traversed)`` where ``tail`` is the last node reached by following
+        single-user transparent shape-only ops (``node`` itself if there are none),
+        and ``traversed`` is the tuple of transparent nodes stepped through, in order.
+        ``tail`` equals ``traversed[-1]`` whenever any ops were traversed.
+    """
+    traversed: list[Node] = []
+    while len(node.users) == 1:
+        (user,) = node.users
+        if _is_transparent(user):
+            traversed.append(user)
+            node = user
+        else:
+            break
+    return node, tuple(traversed)
+
+
+def _skip_transparent_backward(node: Node) -> Node:
+    """Walk backward through single-user transparent shape-only ops to their producer.
+
+    The single-user guard mirrors ``_skip_transparent_forward``: a transparent node
+    reused by more than one consumer is not private to this bias-add, so the walk
+    stops there rather than crossing it. Without this symmetry the backward (bias)
+    walk could reach a matmul the forward (weight) walk refused to, yielding an
+    inconsistent match that slips past verification.
+
+    Args:
+        node: Node to start from.
+
+    Returns:
+        The first non-transparent (or reused) producer node.
+    """
+    while _is_transparent(node) and len(node.users) == 1 and node.all_input_nodes:
+        node = node.args[0]
+    return node
+
 
 def _is_last_dim_preserving_view(node: Node) -> bool:
     """Check if a node is a last-dim-preserving reshape (``view``/``_unsafe_view``).
@@ -30,19 +119,22 @@ def _is_last_dim_preserving_view(node: Node) -> bool:
     )
 
 
-def _find_add_bias(node: Node) -> tuple[Node, Node] | None:
+def _find_add_bias(node: Node) -> tuple[Node, Node, tuple[Node, ...]] | None:
     """Check if a node feeds into ``aten.add.Tensor`` with a bias parameter.
 
-    Looks for the pattern ``add(node, bias)`` or ``add(bias, node)``
-    among the users of ``node``.
+    Looks for the pattern ``add(node, bias)`` or ``add(bias, node)`` among the users
+    of ``node``, possibly across transparent shape-only ops (e.g. the
+    ``mm → _unsafe_view → squeeze → add`` pattern emitted by Taylor-mode/jet).
 
     Args:
         node: Node whose users to inspect.
 
     Returns:
-        ``(add, bias)`` if a matching add is found, else ``None``.
+        ``(add, bias, traversed)`` if a matching add is found, else ``None``;
+        ``traversed`` are the shape-only nodes between ``node`` and ``add``.
     """
-    for user in node.users:
+    tail, traversed = _skip_transparent_forward(node)
+    for user in tail.users:
         if (
             user.op == "call_function"
             and user.target == aten.add.Tensor
@@ -50,9 +142,9 @@ def _find_add_bias(node: Node) -> tuple[Node, Node] | None:
             and not user.kwargs
         ):
             lhs, rhs = user.args
-            bias = rhs if lhs == node else lhs if rhs == node else None
+            bias = rhs if lhs == tail else lhs if rhs == tail else None
             if bias is not None and bias.meta["val"].ndim == 1:
-                return user, bias
+                return user, bias, traversed
 
 
 def _extract_weight(WT: Node) -> Node | str:
@@ -140,18 +232,27 @@ def _match_mm_weight(
         and _is_last_dim_preserving_view(y_view := next(iter(mm.users)))
     ):
         x = x_view.args[0]
+        # The bias (if any) may be added after the output view, possibly through
+        # transparent shape ops (Taylor-mode/jet: view → add, or → squeeze → add).
+        # The layer output is the bias add when present (post-bias), else the view.
         add_result = _find_add_bias(y_view)
         if add_result is not None:
-            y, bias = add_result
-            return AffineLayerInfo(LINEAR_STR, y, p, x, bias, {}), (y_view, y)
-        y = y_view
-        return AffineLayerInfo(LINEAR_STR, y, p, x, None, {}), (y_view,)
+            add_node, bias, traversed = add_result
+            return AffineLayerInfo(LINEAR_STR, add_node, p, x, bias, {}), (
+                y_view,
+                *traversed,
+                add_node,
+            )
+        return AffineLayerInfo(LINEAR_STR, y_view, p, x, None, {}), (y_view,)
 
     # 2D case: mm [→ add]
     add_result = _find_add_bias(mm)
     if add_result is not None:
-        y, bias = add_result
-        return AffineLayerInfo(LINEAR_STR, y, p, x, bias, {}), (y,)
+        add_node, bias, traversed = add_result
+        return AffineLayerInfo(LINEAR_STR, add_node, p, x, bias, {}), (
+            *traversed,
+            add_node,
+        )
     y = mm
     return AffineLayerInfo(LINEAR_STR, y, p, x, None, {}), ()
 
@@ -209,23 +310,24 @@ def _match_add_bias(
     if len(add.args) != 2 or add.kwargs or p.meta["val"].ndim != 1:
         return None
     lhs, rhs = add.args
-    y_view = lhs if rhs == p else rhs if lhs == p else None
-    if y_view is None:
+    other = lhs if rhs == p else rhs if lhs == p else None
+    if other is None:
         return None
 
-    # Expect: view → mm → view (= y_view) → add
-    if not _is_last_dim_preserving_view(y_view):
-        return None
-    mm = y_view.args[0]
+    # Expect: ... → mm → (transparent shape ops) → add. Skip any transparent ops
+    # (view/_unsafe_view/squeeze/...) back to the producing matmul. This covers both
+    # the plain ``view → mm → view → add`` (>2D F.linear) and the Taylor-mode/jet
+    # ``mm → _unsafe_view → squeeze → add`` pattern.
+    mm = _skip_transparent_backward(other)
     if not (mm.op == "call_function" and mm.target == aten.mm.default):
         return None
     x_view, WT = mm.args
-    if not _is_last_dim_preserving_view(x_view):
-        return None
-
     W = _extract_weight(WT)
-    x, y = x_view.args[0], add
-    return AffineLayerInfo(LINEAR_STR, y, W, x, p, {}), ()
+    # Mirror the weight matcher's input convention (unwrap a last-dim-preserving input
+    # view) so the weight- and bias-side infos are identical and deduplicate. The
+    # output is the bias ``add`` (post-bias), matching the weight matcher.
+    x = x_view.args[0] if _is_last_dim_preserving_view(x_view) else x_view
+    return AffineLayerInfo(LINEAR_STR, add, W, x, p, {}), ()
 
 
 class LinearWeightMatcher(_PatternMatcher):

--- a/curvlinops/computers/io_collector/verification.py
+++ b/curvlinops/computers/io_collector/verification.py
@@ -99,11 +99,15 @@ def verify_match_complete(
         max_length = max([len(path) for path in detected_paths_from_p] + [2])
 
         for path in _find_all_paths_from(p, max_length):
-            # Check if this usage path starts with any detected path
+            # A usage path is covered when it and some detected path agree up to the
+            # shorter of the two (one is a prefix of the other). Both directions are
+            # needed: the real path may be shorter (a partial prefix) or longer,
+            # continuing downstream past the matched layer output -- expected for a
+            # weight reused in matmuls of uneven reshape depth (Taylor-mode/jet), not
+            # a real gap.
             is_covered = any(
-                path == detected_path[: len(path)]
-                if len(path) <= len(detected_path)
-                else False
+                path[: len(detected_path)] == detected_path
+                or path == detected_path[: len(path)]
                 for detected_path in detected_paths_from_p
             )
             if not is_covered:

--- a/test/computers/io_collector/test_kfac_io.py
+++ b/test/computers/io_collector/test_kfac_io.py
@@ -386,6 +386,43 @@ def test_kfac_io_cnn(inplace: bool):
         _verify_kfac_io(f, x, params, fisher_type, kfac_io_true)
 
 
+def test_kfac_io_weight_tying_through_reshaped_bias():
+    """KFAC IO for a weight reused across reshape-wrapped coefficient matmuls.
+
+    Mirrors collapsed Taylor mode / jet: one Linear ``(W, b)`` applied to several
+    Taylor coefficients that share the weight, with the bias added to the forward
+    coefficient through a transparent reshape chain (``mm → unsqueeze → squeeze →
+    add(bias)``). Checks that KFAC groups the tied-weight usages into separate layers
+    and collects the correct per-coefficient inputs/outputs across Fisher types.
+    """
+    manual_seed(0)
+    N, D_in, D_out = 2, 3, 4
+
+    def f(params: dict, x: Tensor) -> Tensor:
+        W, b = params["weight"], params["bias"]
+        c0, c1 = x, 2.0 * x
+        y0 = (c0 @ W.t()).unsqueeze(1).squeeze(1) + b  # forward: reshape-wrapped bias
+        y1 = c1 @ W.t()  # derivative coefficient: no bias
+        return y0 + y1
+
+    x = rand(N, D_in)
+    params = {"weight": rand(D_out, D_in), "bias": rand(D_out)}
+    c0, c1 = x, 2.0 * x
+    W = params["weight"]
+
+    for fisher_type in FisherType:
+        kfac_io_true = (
+            f(params, x),
+            {"Linear0": c0, "Linear1": c1},
+            {}
+            if fisher_type == FisherType.FORWARD_ONLY
+            else {"Linear0": linear(c0, W, params["bias"]), "Linear1": linear(c1, W)},
+            {"Linear0": {"W": "weight", "b": "bias"}, "Linear1": {"W": "weight"}},
+            {"Linear0": {}, "Linear1": {}},
+        )
+        _verify_kfac_io(f, x, params, fisher_type, kfac_io_true)
+
+
 def test_kfac_io_flatten_requires_per_batch_size_tracing():
     """Demonstrate that ``nn.Flatten`` bakes in the batch size during real tracing.
 

--- a/test/computers/io_collector/test_param_io.py
+++ b/test/computers/io_collector/test_param_io.py
@@ -305,6 +305,119 @@ def test_supports_multiple_batch_sizes():
         compare_io(io, io_true)
 
 
+@mark.parametrize(
+    "reshape",
+    [
+        lambda y, N, D_out: y.unsqueeze(1).squeeze(1),  # rank-preserving: (N, D_out)
+        lambda y, N, D_out: y.reshape(
+            N, 1, 1, D_out
+        ),  # rank-changing: (N, 1, 1, D_out)
+    ],
+    ids=["rank_preserving", "rank_changing"],
+)
+def test_bias_add_through_transparent_reshapes(reshape):
+    """Detect a Linear whose bias is added after transparent reshapes.
+
+    The traversal is driven purely by the last-dim invariant, so it must match the
+    bias-add whether the transparent reshapes preserve the rank (``unsqueeze.squeeze``)
+    or change it (``reshape`` to more axes), as long as the last dim ``D_out`` stays
+    put. The recorded output is the reshaped tensor, so input and output may differ
+    in rank.
+
+    Args:
+        reshape: Last-dim-preserving reshape applied between the matmul and the bias.
+    """
+    manual_seed(0)
+    N, D_in, D_out = 3, 4, 5
+
+    def f(params: dict, x: Tensor) -> Tensor:
+        y = x @ params["weight"].t()  # mm
+        y = reshape(y, N, D_out)  # transparent: last dim D_out preserved
+        return y + params["bias"]
+
+    x = rand(N, D_in)
+    params = {"weight": rand(D_out, D_in), "bias": rand(D_out)}
+    y = reshape(linear(x, params["weight"], params["bias"]), N, D_out)
+    io_true = ((LINEAR_STR, y, x, "weight", "bias", {}),)
+    _verify_io(f, x, params, io_true)
+
+
+def test_weight_reused_across_reshape_wrapped_matmuls():
+    """Detect one weight reused across matmuls of uneven reshape depth (Taylor mode)."""
+    manual_seed(0)
+    N, D_in, D_out = 3, 4, 5
+
+    def f(params: dict, x: Tensor) -> Tensor:
+        W, b = params["weight"], params["bias"]
+        c0, c1, c2 = x, 2.0 * x, 3.0 * x
+        y0 = (c0 @ W.t()).unsqueeze(1).squeeze(1) + b  # forward: reshape-wrapped bias
+        y1 = c1 @ W.t()  # 1st-order coefficient: no bias, reshape depth 0
+        y2 = (c2 @ W.t()).reshape(N, D_out)  # 2nd-order coefficient: no bias, depth 1
+        return y0 + y1 + y2
+
+    x = rand(N, D_in)
+    params = {"weight": rand(D_out, D_in), "bias": rand(D_out)}
+    c0, c1, c2 = x, 2.0 * x, 3.0 * x
+    W = params["weight"]
+    io_true = (
+        (LINEAR_STR, linear(c0, W, params["bias"]), c0, "weight", "bias", {}),
+        (LINEAR_STR, linear(c1, W), c1, "weight", None, {}),
+        (LINEAR_STR, linear(c2, W), c2, "weight", None, {}),
+    )
+    _verify_io(f, x, params, io_true)
+
+
+def test_bias_after_last_dim_altering_reshape_not_matched():
+    """Transparent-bias traversal must stop at a reshape that alters the last dim.
+
+    ``mm → squeeze (transparent) → reshape (alters last dim) → add(bias)`` must NOT
+    absorb the bias: the reshape changes the feature dimension, so the ``add`` no
+    longer belongs to the matmul. The bias usage is then undetected and rejected. This
+    guards the extended matcher against over-matching through non-transparent shape
+    ops.
+    """
+    manual_seed(0)
+    N, D_in, D_out = 3, 8, 4
+
+    def f(params: dict, x: Tensor) -> Tensor:
+        y = x @ params["weight"].t()  # (N, 4)
+        y = y.unsqueeze(1).squeeze(1)  # transparent (last dim 4 preserved)
+        y = y.reshape(N, 2, 2)  # alters last dim 4 -> 2 (not transparent)
+        return y + params["bias"]
+
+    x_dummy = zeros(N, D_in)
+    params_dummy = {"weight": zeros(D_out, D_in), "bias": zeros(2)}
+
+    with raises(ValueError, match="Some parameters are used in unsupported patterns."):
+        _ = with_param_io(f, x_dummy, params_dummy)
+
+
+def test_bias_through_reused_transparent_node_not_matched():
+    """A transparent node between matmul and bias-add must be private to the bias-add.
+
+    ``mm → unsqueeze → squeeze → add(bias)`` with the intermediate ``unsqueeze``
+    also consumed elsewhere is not a clean linear layer. The forward (weight) walk
+    already stops at the reused node; the backward (bias) walk must stop there too,
+    so the bias fails to match and the usage is rejected. Without the symmetric
+    single-user guard the bias side would reach the matmul, producing an
+    inconsistent match that slips past verification (a silent failure).
+    """
+    manual_seed(0)
+    N, D_in, D_out = 3, 4, 5
+
+    def f(params: dict, x: Tensor) -> Tensor:
+        W, b = params["weight"], params["bias"]
+        t1 = (x @ W.t()).unsqueeze(1)  # transparent node, reused below
+        y = t1.squeeze(1) + b  # bias-add reached past the reused node
+        return y + t1.sum()  # extra consumer of t1
+
+    x_dummy = zeros(N, D_in)
+    params_dummy = {"weight": zeros(D_out, D_in), "bias": zeros(D_out)}
+
+    with raises(ValueError, match="Some parameters are used in unsupported patterns."):
+        _ = with_param_io(f, x_dummy, params_dummy)
+
+
 @mark.parametrize("bias", [True, False], ids=["bias", "no_bias"])
 @mark.parametrize(
     "x_shape",


### PR DESCRIPTION
## What

Make the FX layer-IO matcher robust to graphs that wrap a `Linear`'s matmul in
transparent, last-dim-preserving shape ops and add the bias only after them —
e.g. **collapsed Taylor-mode / [jet](https://github.com/f-dangel/torch-jet) graphs** that emit `mm → _unsafe_view → squeeze → add(bias)` and reuse one weight across several such matmuls (one per Taylor coefficient).

## Why

This is driven by KFAC for **PINNs**: the PDE residual of e.g. a Poisson equation
is computed with collapsed Taylor mode, which applies a single `Linear` layer to
several Taylor coefficients (`c0`/`c1`/`c2`) that *share the weight*, and adds the
bias to the forward coefficient only — reached through a transparent reshape chain.
The previous matcher recognized a bias `add` only *directly* after the view/addmm,
so these biases went undetected and the parameters were reported as used in
unsupported patterns.

## Changes

- **`linear.py`**: traverse last-dim-preserving transparent ops
  (`view`/`_unsafe_view`/`reshape`/`squeeze`/`unsqueeze`) when linking a bias `add`
  to its matmul, on both the weight and bias sides, keeping the two infos identical
  so they deduplicate. Reshapes that alter the last (feature) dimension are still
  rejected.
- **`verification.py`**: treat a usage path as covered when a detected path is a
  *prefix of it* (the usage reached a matched layer output and merely continues
  downstream), not only when the usage is a prefix *of* a detected path. Without
  this, a weight reused in matmuls of uneven reshape depth was spuriously reported
  as uncovered.

Existing behavior is unchanged for standard `nn.Module` graphs.

## Tests

New tests in `test/computers/io_collector/` (all pass; the positive ones fail on
the parent commit, confirming they guard the feature):

- `test_bias_add_through_transparent_reshapes` — bias reached through
  `mm → unsqueeze → squeeze → add(bias)` is linked to its layer.
- `test_weight_reused_across_reshape_wrapped_matmuls` — one weight across three
  coefficient matmuls of differing reshape depth (only the forward one biased).
- `test_bias_after_last_dim_altering_reshape_not_matched` — a reshape that alters
  the last dimension must **not** absorb the bias (guards against over-matching).
- `test_kfac_io_weight_tying_through_reshaped_bias` — end-to-end KFAC IO grouping
  for the tied-weight, reshape-wrapped-bias structure across all Fisher types.

The tests are engineered (no dependency on jet-for-pytorch) so they stay lightweight
and self-contained while covering the exact graph-structural contract.

Full suite green locally (`test/computers/` + `test/test_kfac.py`: 986 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)