### PR TITLE
[DOC] Update property docstrings for `ruff 0.15.20` conventions

### DIFF
--- a/curvlinops/blockdiagonal.py
+++ b/curvlinops/blockdiagonal.py
@@ -124,7 +124,7 @@ class BlockDiagonalLinearOperator(PyTorchLinearOperator):
 
     @property
     def device(self) -> device:
-        """Get the device of the linear operator.
+        """The device of the linear operator.
 
         Returns:
             Device of the blocks.
@@ -133,7 +133,7 @@ class BlockDiagonalLinearOperator(PyTorchLinearOperator):
 
     @property
     def dtype(self) -> dtype:
-        """Get the dtype of the linear operator.
+        """The dtype of the linear operator.
 
         Returns:
             Data type of the blocks.

--- a/curvlinops/eigh.py
+++ b/curvlinops/eigh.py
@@ -62,7 +62,7 @@ class EighDecomposedLinearOperator(PyTorchLinearOperator):
 
     @property
     def eigenvalues(self) -> Tensor:
-        """Return the eigenvalues.
+        """The eigenvalues.
 
         Returns:
             1D tensor of eigenvalues.
@@ -106,7 +106,7 @@ class EighDecomposedLinearOperator(PyTorchLinearOperator):
 
     @property
     def device(self) -> device:
-        """Return the device of the eigendecomposition.
+        """The device of the eigendecomposition.
 
         Returns:
             Device of the eigenvalues and eigenvectors.
@@ -115,7 +115,7 @@ class EighDecomposedLinearOperator(PyTorchLinearOperator):
 
     @property
     def dtype(self) -> dtype:
-        """Return the data type of the eigendecomposition.
+        """The data type of the eigendecomposition.
 
         Returns:
             Data type of the eigenvalues and eigenvectors.

--- a/curvlinops/examples/__init__.py
+++ b/curvlinops/examples/__init__.py
@@ -197,7 +197,7 @@ class OuterProductLinearOperator(PyTorchLinearOperator):
 
     @property
     def dtype(self) -> dtype:
-        """Return the data type of the linear operator.
+        """The data type of the linear operator.
 
         Returns:
             The data type of the linear operator.
@@ -206,7 +206,7 @@ class OuterProductLinearOperator(PyTorchLinearOperator):
 
     @property
     def device(self) -> device:
-        """Return the linear operator's device.
+        """The linear operator's device.
 
         Returns:
             The device on which the linear operator is defined.

--- a/curvlinops/kfac_utils.py
+++ b/curvlinops/kfac_utils.py
@@ -243,7 +243,7 @@ class _CanonicalizationLinearOperator(PyTorchLinearOperator):
 
     @property
     def device(self):
-        """Return the stored device.
+        """The stored device.
 
         Returns:
             The device of the parameters.
@@ -252,7 +252,7 @@ class _CanonicalizationLinearOperator(PyTorchLinearOperator):
 
     @property
     def dtype(self):
-        """Return the stored dtype.
+        """The stored dtype.
 
         Returns:
             The dtype of the parameters.

--- a/curvlinops/kronecker.py
+++ b/curvlinops/kronecker.py
@@ -183,7 +183,7 @@ class KroneckerProductLinearOperator(PyTorchLinearOperator):
 
     @property
     def device(self) -> device:
-        """Return the device of the Kronecker factors.
+        """The device of the Kronecker factors.
 
         Returns:
             Device of the factors.
@@ -192,7 +192,7 @@ class KroneckerProductLinearOperator(PyTorchLinearOperator):
 
     @property
     def dtype(self) -> dtype:
-        """Return the data type of the Kronecker factors.
+        """The data type of the Kronecker factors.
 
         Returns:
             Data type of the factors.

--- a/test/utils.py
+++ b/test/utils.py
@@ -221,7 +221,7 @@ class WeightShareModel(Sequential):
 
     @property
     def setting(self) -> str:
-        """Return the setting of the model.
+        """The setting of the model.
 
         Returns:
             The setting of the model.
@@ -253,7 +253,7 @@ class WeightShareModel(Sequential):
 
     @property
     def loss(self) -> str:
-        """Return the type of loss function the model is used with.
+        """The type of loss function the model is used with.
 
         Returns:
             The type of loss function.
@@ -437,7 +437,7 @@ class Conv2dModel(Module):
 
     @property
     def setting(self) -> str:
-        """Return the setting of the model.
+        """The setting of the model.
 
         Returns:
             The setting of the model.


### PR DESCRIPTION
## What

Reword every property docstring that opened with an imperative verb ("Get the ..." /
"Return the ...") to a noun phrase describing the returned value (e.g. "The device of
the linear operator."). The `Returns:` sections are left unchanged.

## Why

`make install-lint` installs ruff **unpinned**, so CI now runs **ruff 0.15.20**, which
enforces the preview rule **`property-docstring-starts-with-verb`**: a property's
summary should read as a value (noun phrase), not a command. The repo's existing
property docstrings predate this rule, so `make ruff-check` fails on `main` today —
independently of any feature branch. This clears all 14 occurrences so `main` is green
again under the latest ruff, keeping the codebase current with evolving conventions
(no pinning).

## Changes

Property docstring summaries reworded in:
- `curvlinops/blockdiagonal.py` (`device`, `dtype`)
- `curvlinops/eigh.py` (`eigenvalues`, `device`, `dtype`)
- `curvlinops/examples/__init__.py` (`dtype`, `device`)
- `curvlinops/kfac_utils.py` (`device`, `dtype`)
- `curvlinops/kronecker.py` (`device`, `dtype`)
- `test/utils.py` (`setting` ×2, `loss`)

No code behavior changes.

## Verification

With ruff 0.15.20 (the version CI installs):
- `ruff check curvlinops test --preview` → **All checks passed!**
- `ruff format --check` → 100 files already formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)